### PR TITLE
Rewrite vim syntax highlighting

### DIFF
--- a/src/starkware/cairo/lang/ide/vim/syntax/cairo.vim
+++ b/src/starkware/cairo/lang/ide/vim/syntax/cairo.vim
@@ -1,30 +1,49 @@
 " Vim syntax file
-"
-" Language: CAIRO
+" Language: Cairo
+" Author: Zolmeister
+" Last Change: Feb 11, 2021
 
 if exists("b:current_syntax")
   finish
 endif
 
-syntax include @python syntax/python.vim
+syn keyword cairoConditional if else end
+syn keyword cairoKeyword func nextgroup=cairoFuncName skipwhite skipempty
+syn keyword cairoKeyword struct namespace nextgroup=cairoIdentifier skipwhite skipempty
+syn keyword cairoKeyword call jmp ret abs rel
+syn keyword cairoRegister ap fp
+syn keyword cairoKeyword const let local tempvar as from import static_assert return assert member cast alloc_locals 
+syn keyword cairoType felt
+syn keyword cairoItalic SIZEOF_LOCALS SIZE
+syn keyword cairoTodo contained TODO FIXME XXX NB NOTE SAFETY
+
+syn region cairoCommentLine start="#" end="$" contains=cairoTodo,@Spell
+
+syn match cairoIdentifier "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
+syn match cairoFuncName "\%(r#\)\=\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
+syn match cairoFuncCall "\w\(\w\)*("he=e-1,me=e-1
+syn match cairoDecNumber display "\<\d\+\>"
+syn match cairoOperator display "\%(+\|-\|/\|*\|=\|\^\|&\||\|!\|>\|<\|%\)=\?"
+
+" embedded python
+syn include @python syntax/python.vim
+unlet b:current_syntax
+syn region pythonStyle matchgroup=cairoEmbed start=+%{+ keepend end=+%}+ contains=@python
+syn region pythonStyle matchgroup=cairoEmbed start=+%\[+ keepend end=+%\]+ contains=@python
+
+hi def link cairoKeyword Keyword
+hi def link cairoRegister Identifier
+hi def link cairoIdentifier Identifier
+hi def link cairoFuncName Function
+hi def link cairoFuncCall Function
+hi def link cairoType Type
+hi def link cairoConditional Conditional
+hi def link cairoItalic Special
+hi def link cairoCommentLine Comment
+hi def link cairoTodo Todo
+hi def link cairoDecNumber Number
+hi def link cairoOperator Operator
+hi def link cairoEmbed SpecialComment
 
 let b:current_syntax = "cairo"
 
-hi def link statement Statement
-hi def link register Identifier
-hi def link comment Comment
-hi def link funcDef Statement
-hi def link funcName Function
-hi def link num Constant
-hi def link specialIdentifier Special
-
-syn keyword statement call jmp ret abs rel if const let end from import static_assert local tempvar
-  \ felt return assert member cast else alloc_locals
-syn keyword register ap fp
-syn keyword specialIdentifier SIZEOF_LOCALS SIZE
-syn match comment '#[^\n]*\n'
-syn keyword funcDef func namespace struct nextgroup=funcName skipwhite
-syn match funcName '[a-zA-Z_][a-zA-Z0-9_]*' display contained
-syn match num '[+-]\?\d\+'
-syn region cairoHint matchgroup=SpecialComment start="%{" keepend end="%}" contains=@python
-syn region pythonLiteral matchgroup=SpecialComment start="%\[" keepend end="%\]" contains=@python


### PR DESCRIPTION
I was unaware an existing vim syntax existed before implementation. This version improves function/struct highlighting, among other small details. Please update the documentation to reference this file.