### PR TITLE
A simple disassembler for Cairo instructions.

### DIFF
--- a/src/starkware/cairo/lang/compiler/CMakeLists.txt
+++ b/src/starkware/cairo/lang/compiler/CMakeLists.txt
@@ -23,6 +23,7 @@ python_lib(cairo_compile_lib
     cairo.ebnf
     constants.py
     const_expr_checker.py
+    disassembler.py
     debug_info.py
     encode.py
     error_handling.py
@@ -110,6 +111,7 @@ full_python_test(cairo_compile_test
     ast_objects_test.py
     ast/formatting_utils_test.py
     cairo_compile_test.py
+    disassembler_test.py
     encode_test.py
     error_handling_test.py
     expression_evaluator_test.py

--- a/src/starkware/cairo/lang/compiler/disassembler.py
+++ b/src/starkware/cairo/lang/compiler/disassembler.py
@@ -1,0 +1,177 @@
+from starkware.cairo.lang.compiler.instruction import (
+    Instruction, Register, decode_instruction_values)
+from starkware.cairo.lang.compiler.instruction_builder import (
+    InstructionBuilderError, build_instruction)
+from starkware.cairo.lang.compiler.parser import parse_instruction
+
+
+def parse_build_disassemble(inst: str) -> str:
+    """
+    Parses the given instruction and builds the Instruction instance.
+    """
+    return disassemble_instruction(build_instruction(parse_instruction(inst)))
+
+
+def disassemble_off(off) -> str:
+    """
+    Append the string "+<off>" or "-<off>" if <off> is nonzero.
+    """
+    instr: str = ""
+    if off < 0:
+        instr += str(off)
+    elif off > 0:
+        instr += "+" + str(off)
+    return instr
+
+
+def disassemble_source_operand(instruction: Instruction) -> str:
+    """
+    For asserts, jumps, and increment-ap instructions, disassemble the
+    right-hand side of the assert, the target of the jump, and the value of the
+    ap-register increment respectively.
+    """
+    instr: str = " "
+    # parse the source
+    if instruction.res is Instruction.Res.OP1:
+        # either immediate or dereference
+        if instruction.op1_addr is Instruction.Op1Addr.IMM:
+            # Immediate operand
+            instr += str(instruction.imm)
+        elif instruction.op1_addr is Instruction.Op1Addr.OP0:
+            # Double dereference
+            instr += "[["
+            instr += 'ap' if instruction.op0_register is Register.AP else 'fp'
+            instr += disassemble_off(instruction.off1)
+            instr += "]"
+            instr += disassemble_off(instruction.off2)
+            instr += "]"
+        else:
+            # Single derefernce
+            instr += "["
+            instr += 'ap' if instruction.op1_addr is Instruction.Op1Addr.AP else 'fp'
+            instr += disassemble_off(instruction.off2)
+            instr += "]"
+    else:
+        # [reg + off] */+ [reg + off] or [reg + off] */+ imm
+        instr += "["
+        instr += 'fp' if instruction.op0_register is Register.FP else 'ap'
+        instr += disassemble_off(instruction.off1)
+        instr += "]"
+        instr += ' * ' if instruction.res is Instruction.Res.MUL else ' + '
+        if instruction.op1_addr is Instruction.Op1Addr.IMM:
+            instr += str(instruction.imm)
+        else:
+            instr += "["
+            instr += 'fp' if instruction.op1_addr is Instruction.Op1Addr.FP else 'ap'
+            instr += disassemble_off(instruction.off2)
+            instr += "]"
+    return instr
+
+
+def disassemble_assert_eq_instruction(instruction: Instruction) -> str:
+    """
+    Disassemble A = B instructions.  Note that the disassembly may not be
+    identical to what was provided in the source code, due to syntactic sugar,
+    though the instruction encoding will be.
+    """
+    instr: str = ""
+    # parse the destination
+    if instruction.dst_register is Register.AP:
+        instr += "[ap"
+    elif instruction.dst_register is Register.FP:
+        instr += "[fp"
+    instr += disassemble_off(instruction.off0)
+    instr += "] = "
+
+    instr += disassemble_source_operand(instruction)
+    return instr
+
+
+def disassemble_jump_instruction(instruction: Instruction) -> str:
+    """
+    Disassemble all jmp-instruction variants.
+    """
+    instr: str = "jmp"
+    if instruction.pc_update is Instruction.PcUpdate.JUMP:
+        instr += " abs"
+    else:
+        instr += " rel"
+
+    if instruction.res is Instruction.Res.UNCONSTRAINED:
+        # jnz
+        if instruction.op1_addr is Instruction.Op1Addr.IMM:
+            instr += " " + str(instruction.imm)
+        else:
+            if instruction.op1_addr is Instruction.Op1Addr.FP:
+                instr += " [fp"
+            else:
+                instr += " [ap"
+            instr += disassemble_off(instruction.off2)
+            instr += "]"
+    else:
+        # jmp
+        instr += disassemble_source_operand(instruction)
+
+    if instruction.off0 != -1:
+        # conditional jump
+        instr += " if ["
+        instr += "ap" if instruction.dst_register is Register.AP else "fp"
+        instr += disassemble_off(instruction.off0)
+        instr += "] != 0"
+
+    return instr
+
+
+def disassemble_call_instruction(instruction: Instruction) -> str:
+    """
+    Disassemble the call instruction.
+    """
+    instr: str = "call"
+    if instruction.pc_update is Instruction.PcUpdate.JUMP_REL:
+        instr += " rel"
+    else:
+        instr += " abs"
+    if instruction.op1_addr is Instruction.Op1Addr.IMM:
+        instr += " " + str(instruction.imm)
+    else:
+        instr += " ["
+        instr += "ap" if instruction.op1_addr is Instruction.Op1Addr.AP else "fp"
+        instr += disassemble_off(instruction.off2)
+        instr += "]"
+
+    return instr
+
+
+def disassemble_ap_add_instruction(instruction: Instruction) -> str:
+    """
+    Disassemble the ap-increment instruction.
+    """
+    instr: str = "ap +="
+    instr += disassemble_source_operand(instruction)
+    return instr
+
+
+def disassemble_instruction(instruction: Instruction) -> str:
+    """
+    Returns a disssassembly of an Instruction.  The encoding of the
+    disassembled instruction string will equal encoding of the input
+    instruction.  The input Instruction object is assumed to be well-formed.
+    """
+    instr: str = ""
+    if instruction.opcode is Instruction.Opcode.RET:
+        return "ret"
+    elif instruction.opcode is Instruction.Opcode.NOP:
+        if instruction.ap_update is Instruction.ApUpdate.ADD:
+            instr = disassemble_ap_add_instruction(instruction)
+        else:
+            instr = disassemble_jump_instruction(instruction)
+    elif instruction.opcode is Instruction.Opcode.CALL:
+        instr = disassemble_call_instruction(instruction)
+    elif instruction.opcode is Instruction.Opcode.ASSERT_EQ:
+        instr = disassemble_assert_eq_instruction(instruction)
+
+    # parse the AP update
+    if instruction.ap_update is Instruction.ApUpdate.ADD1:
+        instr += "; ap++"
+
+    return instr

--- a/src/starkware/cairo/lang/compiler/disassembler_test.py
+++ b/src/starkware/cairo/lang/compiler/disassembler_test.py
@@ -1,0 +1,74 @@
+import pytest
+
+from starkware.cairo.lang.compiler.instruction import Instruction
+from starkware.cairo.lang.compiler.instruction_builder import build_instruction
+from starkware.cairo.lang.compiler.parser import parse_instruction
+from starkware.cairo.lang.compiler.encode import encode_instruction
+from starkware.cairo.lang.compiler.disassembler import disassemble_instruction
+from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
+
+
+def parse_loop(inst: str):
+    """
+    Parses the given instruction, builds the Instruction instance, then
+    disassembles the Instruction instance.  Compares the original Instruction's
+    encoding to the reconstructed Instruction's encoding and asserts that the
+    two are identical.
+    """
+    i1 = build_instruction(parse_instruction(inst))
+    e1 = encode_instruction(i1, DEFAULT_PRIME)
+    i2 = build_instruction(parse_instruction(disassemble_instruction(i1)))
+    e2 = encode_instruction(i2, DEFAULT_PRIME)
+    assert e1[0] == e2[0]
+    if len(e1) == 2:
+        assert e1[1] == e2[1]
+
+
+def test_assert_eq():
+    parse_loop('[ap] = [fp]; ap++')
+    parse_loop('[fp - 3] = [fp + 7]')
+    parse_loop('[ap - 3] = [ap]')
+
+
+def test_assert_eq_double_dereference():
+    parse_loop('[ap + 2] = [[fp]]')
+    parse_loop('[ap + 2] = [[ap - 4] + 7]; ap++')
+
+
+def test_assert_eq_imm():
+    parse_loop('[ap + 2] = 1234567890')
+
+
+def test_assert_eq_operation():
+    parse_loop('[ap + 1] = [ap - 7] * [fp + 3]')
+    parse_loop('[ap + 10] = [fp] + 1234567890')
+    parse_loop('[fp - 3] = [ap + 7] * [ap + 8]')
+
+
+def test_jump_instruction():
+    parse_loop('jmp rel [ap + 1] + [fp - 7]')
+    parse_loop('jmp abs 123; ap++')
+    parse_loop('jmp rel [ap + 1] + [ap - 7]')
+
+
+def test_jnz_instruction():
+    parse_loop('jmp rel [fp - 1] if [fp - 7] != 0')
+    parse_loop('jmp rel [ap - 1] if [fp - 7] != 0')
+    parse_loop('jmp rel 123 if [ap] != 0; ap++')
+
+
+def test_call_instruction():
+    parse_loop('call abs [fp + 4]')
+    parse_loop('call rel [fp + 4]')
+    parse_loop('call rel [ap + 4]')
+    parse_loop('call rel 123')
+
+
+def test_ret_instruction():
+    parse_loop('ret')
+
+
+def test_addap_instruction():
+    parse_loop('ap += [fp + 4] + [fp]')
+    parse_loop('ap += [ap + 4] + [ap]')
+    parse_loop('ap += 123')


### PR DESCRIPTION
The disassembler will convert an Instruction object back to a string
representation of the corresponding instruction, such that the binary
encoding of the input Instruction and the binary encoding of the
Instruction object generated from parsing the result are identical.

Signed-off-by: Iliyan Malchev <malchev@gmail.com>