### PR TITLE
Allow future function label assignment.

### DIFF
--- a/src/starkware/cairo/lang/compiler/ast/expr.py
+++ b/src/starkware/cairo/lang/compiler/ast/expr.py
@@ -318,7 +318,7 @@ class ExprFutureLabel(Expression):
         return self.identifier.to_expr_str()
 
     @property
-    def locaion(self):
+    def location(self):
         return self.identifier.location
 
     def get_children(self) -> Sequence[Optional[AstNode]]:

--- a/src/starkware/cairo/lang/compiler/preprocessor/compound_expressions.py
+++ b/src/starkware/cairo/lang/compiler/preprocessor/compound_expressions.py
@@ -6,7 +6,7 @@ from starkware.cairo.lang.compiler.ast.cairo_types import TypeFelt
 from starkware.cairo.lang.compiler.ast.code_elements import (
     CodeElement, CodeElementTemporaryVariable)
 from starkware.cairo.lang.compiler.ast.expr import (
-    ExprConst, ExprDeref, Expression, ExprIdentifier, ExprNeg, ExprOperator, ExprReg)
+    ExprConst, ExprDeref, Expression, ExprFutureLabel, ExprIdentifier, ExprNeg, ExprOperator, ExprReg)
 from starkware.cairo.lang.compiler.ast.types import TypedIdentifier
 from starkware.cairo.lang.compiler.error_handling import Location
 from starkware.cairo.lang.compiler.instruction import Register
@@ -135,6 +135,9 @@ class CompoundExpressionVisitor:
         expr = ExprDeref(
             addr=self.rewrite(expr.addr, SimplicityLevel.DEREF_OFFSET), location=expr.location)
         return expr if sim is SimplicityLevel.OPERATION else self.wrap(expr)
+
+    def rewrite_ExprFutureLabel(self, expr: ExprFutureLabel, sim: SimplicityLevel):
+        return expr
 
     def wrap(self, expr: Expression) -> ExprIdentifier:
         identifier = ExprIdentifier(name=self.context.new_tempvar_name(), location=expr.location)

--- a/src/starkware/cairo/lang/compiler/preprocessor/preprocessor.py
+++ b/src/starkware/cairo/lang/compiler/preprocessor/preprocessor.py
@@ -1605,7 +1605,7 @@ Expected expression of type '{expected_type.format()}', got '{expr_type.format()
         assert identifier_definition is not None
 
         if isinstance(identifier_definition, FutureIdentifierDefinition):
-            if identifier_definition.identifier_type == LabelDefinition:
+            if identifier_definition.identifier_type in [LabelDefinition, FunctionDefinition]:
                 # Allow future label assignment.
                 return ExprFutureLabel(identifier=var)
             raise PreprocessorError(

--- a/src/starkware/cairo/lang/compiler/preprocessor/preprocessor_test.py
+++ b/src/starkware/cairo/lang/compiler/preprocessor/preprocessor_test.py
@@ -113,6 +113,20 @@ future_label2:
 """
 
 
+def test_assign_future_function_label():
+    code = """\
+[ap] = a; ap++
+func a() -> ():
+  ret
+end
+"""
+    program = preprocess_str(code=code, prime=PRIME)
+    assert program.format() == """\
+[ap] = 2; ap++
+ret
+"""
+
+
 def test_temporary_variable():
     code = """\
 struct T:


### PR DESCRIPTION
This pull request allows to get the label location of a function which is defined at a later point in the source code.

With this fix, the following program compiles and runs as expected:
```cairo
%builtins output
from starkware.cairo.common.registers import get_label_location

func even(n) -> (result):
  if n == 0:
    return (1)
  else:
    # Here we reference the future function named `odd`
    let (odd_label) = get_label_location(odd)
    [ap] = n - 1; ap++
    call abs odd_label
    ret
  end
end

func odd(n) -> (result):
  if n == 0:
    return (0)
  else:
    let (even_label) = get_label_location(even)
    [ap] = n - 1; ap++
    call abs even_label
    ret
  end
end
  
func main(output_ptr) -> (output_ptr):
  let (res) = even(3)
  assert res = 0
  assert [output_ptr] = res
  return (output_ptr + 1)
end
```

Before this fix the following error was reported:
> Error: code:8:42: Identifier 'odd' referenced before definition.
    let (odd_label) = get_label_location(odd)
>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/8)
<!-- Reviewable:end -->
