### PR TITLE
Make `StarknetContract` picklable

### DIFF
--- a/src/starkware/starknet/testing/contract.py
+++ b/src/starkware/starknet/testing/contract.py
@@ -69,6 +69,12 @@ class StarknetContract:
     def __dir__(self):
         return object.__dir__(self) + list(self._abi_function_mapping.keys())
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+    
     def __getattr__(self, name: str):
         if name in self._abi_function_mapping:
             if name not in self._contract_functions:


### PR DESCRIPTION
The only thing preventing the entire starknet testing state from being serializable with [dill](https://pypi.org/project/dill/) is that a missing `__setstate__` method on `StarknetContract` causes an [an infinite recursion](https://stackoverflow.com/questions/50156118/recursionerror-maximum-recursion-depth-exceeded-while-calling-a-python-object-w/50158865#50158865) on deserialization for the [reason described here](https://nedbatchelder.com/blog/201010/surprising_getattr_recursion.html)

It's useful for the entire starknet state to be serializable, because it will let us use [pytest's caching framework](https://docs.pytest.org/en/latest/how-to/cache.html#the-new-config-cache-object) to cache fixtures that are expensive to compute (i.e. that require deploying many contracts, running initialization transactions, etc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/24)
<!-- Reviewable:end -->
