### PR TITLE
perf: cache file system operations

### DIFF
--- a/src/starkware/starknet/core/os/contract_hash.py
+++ b/src/starkware/starknet/core/os/contract_hash.py
@@ -20,7 +20,6 @@ from starkware.starknet.services.api.contract_definition import ContractDefiniti
 
 CAIRO_FILE = os.path.join(os.path.dirname(__file__), "contracts.cairo")
 
-
 def load_program() -> Program:
     return compile_cairo_files(
         [CAIRO_FILE],
@@ -28,11 +27,14 @@ def load_program() -> Program:
         main_scope=ScopedName.from_string("starkware.starknet.core.os.contracts"),
     )
 
+# Load the Cairo Program as a static so that it gets initialized at the
+# beginning of a script run.
+CAIRO_PROGRAM = load_program()
 
 def compute_contract_hash(
     contract_definition: ContractDefinition, hash_func: Callable[[int, int], int] = pedersen_hash
 ) -> int:
-    program = load_program()
+    program = CAIRO_PROGRAM
     contract_definition_struct = get_contract_definition_struct(
         identifiers=program.identifiers, contract_definition=contract_definition
     )

--- a/src/starkware/starknet/core/os/os_program.py
+++ b/src/starkware/starknet/core/os/os_program.py
@@ -13,8 +13,12 @@ def get_os_program() -> Program:
     with open(STARKNET_OS_COMPILED_PATH, "r") as file:
         return Program.Schema().loads(json_data=file.read())
 
-
 @cachetools.cached(cache={})
 def get_os_program_hash() -> int:
     program = get_os_program()
     return compute_program_hash_chain(program=program)
+
+# Call this once here so that the cache gets warmed up at
+# the beginning of the script run.
+OS_PROGRAM = get_os_program()
+OS_PROGRAM_HASH = get_os_program_hash()


### PR DESCRIPTION
Both `load_program()` and `get_os_program()` had to make a costly read from the filesystem or invoke the compiler. This was being done during program execution, while instead it should only be done once at the beginning of the script, so that it saves time. This in aggregate ends up saving ~2s (out of ~10) when benchmarking against https://github.com/ametel01/cairo-library