### PR TITLE
Fixed Ganache initialisation in eth_test_utils.py

### DIFF
--- a/src/starkware/eth/eth_test_utils.py
+++ b/src/starkware/eth/eth_test_utils.py
@@ -61,7 +61,7 @@ class Ganache:
         """
         self.port = random.randrange(1024, 8192)
         self.ganache_proc = subprocess.Popen(
-            f"ganache-cli -p {self.port} --.chain.chainId 32 --networkId 32 --gasLimit 8000000 "
+            f"ganache-cli -p {self.port} --chain.chainId 32 --networkId 32 --gasLimit 8000000 "
             "--chain.allowUnlimitedContractSize",
             shell=True,
             stdout=subprocess.DEVNULL,

--- a/src/starkware/eth/eth_test_utils.py
+++ b/src/starkware/eth/eth_test_utils.py
@@ -61,8 +61,8 @@ class Ganache:
         """
         self.port = random.randrange(1024, 8192)
         self.ganache_proc = subprocess.Popen(
-            f"ganache-cli -p {self.port} --chainId 32 --networkId 32 --gasLimit 8000000 "
-            "--allow-unlimited-contract-size",
+            f"ganache-cli -p {self.port} --.chain.chainId 32 --networkId 32 --gasLimit 8000000 "
+            "--chain.allowUnlimitedContractSize",
             shell=True,
             stdout=subprocess.DEVNULL,
             # Open the process in a new process group.


### PR DESCRIPTION
I had issues starting the Ganache server using the existing functions in `eth_test_utils.py` due to the arguments passed to ganache-cli. Fixed these arguments here

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/36)
<!-- Reviewable:end -->
