### PR TITLE
Update third party OpenZeppelin Account.cairo to latest version

### DIFF
--- a/src/starkware/starknet/third_party/open_zeppelin/Account.cairo
+++ b/src/starkware/starknet/third_party/open_zeppelin/Account.cairo
@@ -1,71 +1,14 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (account/Account.cairo)
+# OpenZeppelin Contracts for Cairo v0.1.0 (account/Account.cairo)
 
 %lang starknet
 
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
-from starkware.cairo.common.hash_state import (
-    hash_finalize, hash_init, hash_update, hash_update_single)
-from starkware.cairo.common.memcpy import memcpy
-from starkware.cairo.common.registers import get_fp_and_pc
-from starkware.cairo.common.signature import verify_ecdsa_signature
-from starkware.starknet.common.syscalls import (
-    call_contract, get_caller_address, get_contract_address, get_tx_info)
-from starkware.starknet.third_party.open_zeppelin.utils.constants import PREFIX_TRANSACTION
+from starkware.starknet.third_party.open_zeppelin.library import (
+    AccountCallArray, Account_execute, Account_get_nonce, Account_initializer,
+    Account_get_public_key, Account_set_public_key, Account_is_valid_signature)
 
-#
-# Structs
-#
-
-struct MultiCall:
-    member account : felt
-    member calls_len : felt
-    member calls : Call*
-    member nonce : felt
-    member max_fee : felt
-    member version : felt
-end
-
-struct Call:
-    member to : felt
-    member selector : felt
-    member calldata_len : felt
-    member calldata : felt*
-end
-
-# Tmp struct introduced while we wait for Cairo
-# to support passing `[Call]` to __execute__
-struct CallArray:
-    member to : felt
-    member selector : felt
-    member data_offset : felt
-    member data_len : felt
-end
-
-#
-# Storage
-#
-
-@storage_var
-func current_nonce() -> (res : felt):
-end
-
-@storage_var
-func public_key() -> (res : felt):
-end
-
-#
-# Guards
-#
-
-@view
-func assert_only_self{syscall_ptr : felt*}():
-    let (self) = get_contract_address()
-    let (caller) = get_caller_address()
-    assert self = caller
-    return ()
-end
+from starkware.starknet.third_party.open_zeppelin.ERC165 import ERC165_supports_interface
 
 #
 # Getters
@@ -74,14 +17,21 @@ end
 @view
 func get_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
         res : felt):
-    let (res) = public_key.read()
+    let (res) = Account_get_public_key()
     return (res=res)
 end
 
 @view
 func get_nonce{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):
-    let (res) = current_nonce.read()
+    let (res) = Account_get_nonce()
     return (res=res)
+end
+
+@view
+func supportsInterface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        interfaceId : felt) -> (success : felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
 end
 
 #
@@ -91,8 +41,7 @@ end
 @external
 func set_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         new_public_key : felt):
-    assert_only_self()
-    public_key.write(new_public_key)
+    Account_set_public_key(new_public_key)
     return ()
 end
 
@@ -102,8 +51,8 @@ end
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        _public_key : felt):
-    public_key.write(_public_key)
+        public_key : felt):
+    Account_initializer(public_key)
     return ()
 end
 
@@ -115,106 +64,17 @@ end
 func is_valid_signature{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
         ecdsa_ptr : SignatureBuiltin*}(hash : felt, signature_len : felt, signature : felt*) -> ():
-    let (_public_key) = public_key.read()
-
-    # This interface expects a signature pointer and length to make
-    # no assumption about signature validation schemes.
-    # But this implementation does, and it expects a (sig_r, sig_s) pair.
-    let sig_r = signature[0]
-    let sig_s = signature[1]
-
-    verify_ecdsa_signature(
-        message=hash, public_key=_public_key, signature_r=sig_r, signature_s=sig_s)
-
+    Account_is_valid_signature(hash, signature_len, signature)
     return ()
 end
 
 @external
-@raw_output
 func __execute__{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
         ecdsa_ptr : SignatureBuiltin*}(
-        call_array_len : felt, call_array : CallArray*, calldata_len : felt, calldata : felt*,
-        nonce : felt) -> (retdata_size : felt, retdata : felt*):
-    alloc_locals
-
-    let (__fp__, _) = get_fp_and_pc()
-    let (tx_info) = get_tx_info()
-    let (_current_nonce) = current_nonce.read()
-
-    # validate nonce
-    with_attr error_message("Invalid nonce."):
-        assert nonce = _current_nonce
-    end
-
-    # TMP: Convert `CallArray` to 'Call'.
-    let (calls : Call*) = alloc()
-    from_call_array_to_call(call_array_len, call_array, calldata, calls)
-    let calls_len = call_array_len
-
-    local multicall : MultiCall = MultiCall(
-        tx_info.account_contract_address,
-        calls_len,
-        calls,
-        _current_nonce,
-        tx_info.max_fee,
-        tx_info.version
-        )
-
-    # validate transaction
-
-    is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
-
-    # bump nonce
-    current_nonce.write(_current_nonce + 1)
-
-    # execute call
-    let (response : felt*) = alloc()
-    let (response_len) = execute_list(multicall.calls_len, multicall.calls, response)
-
-    return (retdata_size=response_len, retdata=response)
-end
-
-func execute_list{syscall_ptr : felt*}(calls_len : felt, calls : Call*, response : felt*) -> (
-        response_len : felt):
-    alloc_locals
-
-    # if no more calls
-    if calls_len == 0:
-        return (0)
-    end
-
-    # do the current call
-    let this_call : Call = [calls]
-    let res = call_contract(
-        contract_address=this_call.to,
-        function_selector=this_call.selector,
-        calldata_size=this_call.calldata_len,
-        calldata=this_call.calldata)
-    # copy the result in response
-    memcpy(response, res.retdata, res.retdata_size)
-    # do the next calls recursively
-    let (response_len) = execute_list(calls_len - 1, calls + Call.SIZE, response + res.retdata_size)
-    return (response_len + res.retdata_size)
-end
-
-func from_call_array_to_call{syscall_ptr : felt*}(
-        call_array_len : felt, call_array : CallArray*, calldata : felt*, calls : Call*):
-    # if no more calls
-    if call_array_len == 0:
-        return ()
-    end
-
-    # parse the current call
-    assert [calls] = Call(
-        to=[call_array].to,
-        selector=[call_array].selector,
-        calldata_len=[call_array].data_len,
-        calldata=calldata + [call_array].data_offset
-        )
-
-    # parse the remaining calls recursively
-    from_call_array_to_call(
-        call_array_len - 1, call_array + CallArray.SIZE, calldata, calls + Call.SIZE)
-    return ()
+        call_array_len : felt, call_array : AccountCallArray*, calldata_len : felt,
+        calldata : felt*, nonce : felt) -> (response_len : felt, response : felt*):
+    let (response_len, response) = Account_execute(
+        call_array_len, call_array, calldata_len, calldata, nonce)
+    return (response_len=response_len, response=response)
 end

--- a/src/starkware/starknet/third_party/open_zeppelin/ERC165.cairo
+++ b/src/starkware/starknet/third_party/open_zeppelin/ERC165.cairo
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Contracts for Cairo v0.1.0 (introspection/ERC165.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.math import assert_not_equal
+
+from starkware.starknet.third_party.open_zeppelin.utils.constants import (
+    TRUE, INVALID_ID, IERC165_ID)
+
+@storage_var
+func ERC165_supported_interfaces(interface_id : felt) -> (is_supported : felt):
+end
+
+func ERC165_supports_interface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        interface_id : felt) -> (success : felt):
+    if interface_id == IERC165_ID:
+        return (TRUE)
+    end
+
+    # Checks interface registry
+    let (is_supported) = ERC165_supported_interfaces.read(interface_id)
+    return (is_supported)
+end
+
+func ERC165_register_interface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        interface_id : felt):
+    with_attr error_message("ERC165: invalid interface id"):
+        assert_not_equal(interface_id, INVALID_ID)
+    end
+    ERC165_supported_interfaces.write(interface_id, TRUE)
+    return ()
+end

--- a/src/starkware/starknet/third_party/open_zeppelin/library.cairo
+++ b/src/starkware/starknet/third_party/open_zeppelin/library.cairo
@@ -1,0 +1,197 @@
+%lang starknet
+
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.starknet.common.syscalls import get_contract_address
+from starkware.cairo.common.signature import verify_ecdsa_signature
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.memcpy import memcpy
+from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_info
+from starkware.cairo.common.hash_state import (
+    hash_init, hash_finalize, hash_update, hash_update_single)
+
+from starkware.starknet.third_party.open_zeppelin.ERC165 import (
+    ERC165_supports_interface, ERC165_register_interface)
+
+from starkware.starknet.third_party.open_zeppelin.utils.constants import IACCOUNT_ID
+
+#
+# Structs
+#
+
+struct Call:
+    member to : felt
+    member selector : felt
+    member calldata_len : felt
+    member calldata : felt*
+end
+
+# Tmp struct introduced while we wait for Cairo
+# to support passing `[AccountCall]` to __execute__
+struct AccountCallArray:
+    member to : felt
+    member selector : felt
+    member data_offset : felt
+    member data_len : felt
+end
+
+#
+# Storage
+#
+
+@storage_var
+func Account_current_nonce() -> (res : felt):
+end
+
+@storage_var
+func Account_public_key() -> (res : felt):
+end
+
+#
+# Guards
+#
+
+func Account_assert_only_self{syscall_ptr : felt*}():
+    let (self) = get_contract_address()
+    let (caller) = get_caller_address()
+    with_attr error_message("Account: caller is not this account"):
+        assert self = caller
+    end
+    return ()
+end
+
+#
+# Getters
+#
+
+func Account_get_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        ) -> (res : felt):
+    let (res) = Account_public_key.read()
+    return (res=res)
+end
+
+func Account_get_nonce{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
+    let (res) = Account_current_nonce.read()
+    return (res=res)
+end
+
+#
+# Setters
+#
+
+func Account_set_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        new_public_key : felt):
+    Account_assert_only_self()
+    Account_public_key.write(new_public_key)
+    return ()
+end
+
+#
+# Initializer
+#
+
+func Account_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        _public_key : felt):
+    Account_public_key.write(_public_key)
+    ERC165_register_interface(IACCOUNT_ID)
+    return ()
+end
+
+#
+# Business logic
+#
+
+@view
+func Account_is_valid_signature{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        ecdsa_ptr : SignatureBuiltin*}(hash : felt, signature_len : felt, signature : felt*) -> ():
+    let (_public_key) = Account_public_key.read()
+
+    # This interface expects a signature pointer and length to make
+    # no assumption about signature validation schemes.
+    # But this implementation does, and it expects a (sig_r, sig_s) pair.
+    let sig_r = signature[0]
+    let sig_s = signature[1]
+
+    verify_ecdsa_signature(
+        message=hash, public_key=_public_key, signature_r=sig_r, signature_s=sig_s)
+
+    return ()
+end
+
+func Account_execute{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        ecdsa_ptr : SignatureBuiltin*}(
+        call_array_len : felt, call_array : AccountCallArray*, calldata_len : felt,
+        calldata : felt*, nonce : felt) -> (response_len : felt, response : felt*):
+    alloc_locals
+
+    let (__fp__, _) = get_fp_and_pc()
+    let (tx_info) = get_tx_info()
+    let (_current_nonce) = Account_current_nonce.read()
+
+    # validate nonce
+    assert _current_nonce = nonce
+
+    # TMP: Convert `AccountCallArray` to 'Call'.
+    let (calls : Call*) = alloc()
+    from_call_array_to_call(call_array_len, call_array, calldata, calls)
+    let calls_len = call_array_len
+
+    # validate transaction
+    Account_is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
+
+    # bump nonce
+    Account_current_nonce.write(_current_nonce + 1)
+
+    # execute call
+    let (response : felt*) = alloc()
+    let (response_len) = execute_list(calls_len, calls, response)
+
+    return (response_len=response_len, response=response)
+end
+
+func execute_list{syscall_ptr : felt*}(calls_len : felt, calls : Call*, response : felt*) -> (
+        response_len : felt):
+    alloc_locals
+
+    # if no more calls
+    if calls_len == 0:
+        return (0)
+    end
+
+    # do the current call
+    let this_call : Call = [calls]
+    let res = call_contract(
+        contract_address=this_call.to,
+        function_selector=this_call.selector,
+        calldata_size=this_call.calldata_len,
+        calldata=this_call.calldata)
+    # copy the result in response
+    memcpy(response, res.retdata, res.retdata_size)
+    # do the next calls recursively
+    let (response_len) = execute_list(calls_len - 1, calls + Call.SIZE, response + res.retdata_size)
+    return (response_len + res.retdata_size)
+end
+
+func from_call_array_to_call{syscall_ptr : felt*}(
+        call_array_len : felt, call_array : AccountCallArray*, calldata : felt*, calls : Call*):
+    # if no more calls
+    if call_array_len == 0:
+        return ()
+    end
+
+    # parse the current call
+    assert [calls] = Call(
+        to=[call_array].to,
+        selector=[call_array].selector,
+        calldata_len=[call_array].data_len,
+        calldata=calldata + [call_array].data_offset
+        )
+
+    # parse the remaining calls recursively
+    from_call_array_to_call(
+        call_array_len - 1, call_array + AccountCallArray.SIZE, calldata, calls + Call.SIZE)
+    return ()
+end

--- a/src/starkware/starknet/third_party/open_zeppelin/utils/constants.cairo
+++ b/src/starkware/starknet/third_party/open_zeppelin/utils/constants.cairo
@@ -21,3 +21,14 @@ const PREFIX_TRANSACTION = 'StarkNet Transaction'
 #
 
 const UINT8_MAX = 256
+
+#
+# Interface Ids
+#
+
+# ERC165
+const IERC165_ID = 0x01ffc9a7
+const INVALID_ID = 0xffffffff
+
+# Account
+const IACCOUNT_ID = 0xf10dbd44


### PR DESCRIPTION
The version of the third party OpenZeppelin account contract used for deploying accounts in tests and experimentation is not up to date with the latest version of `Account.cairo` in the OpenZeppelin repo. Notably, it does not include ERC165 support with no `supportsInterface` function.

This PR simply updates the Account contract to the current version by OpenZeppelin, alongside any required contract imports - https://github.com/OpenZeppelin/cairo-contracts/blob/main/src/openzeppelin/account/Account.cairo