### PR TITLE
Use sys.executable instead of looking for Python in hardcoded paths

### DIFF
--- a/src/cmake_utils/gen_venv.py
+++ b/src/cmake_utils/gen_venv.py
@@ -102,15 +102,21 @@ def main():
     shutil.rmtree(args.site_dir, ignore_errors=True)
     os.makedirs(args.site_dir)
 
-    if sys.executable is None:
-        raise "Unable to determine Python executable path."
+    python_exec = sys.executable
+    if python_exec is None:
+        # Find python.
+        lookup_paths = [
+            "/usr/bin",
+            "/usr/local/bin",
+        ]
+        python_exec = shutil.which(args.python, path=":".join(lookup_paths))
 
     # Prepare an empty virtual environment in the background.
     # --symlinks prefers symlinks of copying.
     # --without-pip installs a completely empty venv, with no pip.
     # --clear clears the old venv if exists.
     venv_proc = subprocess.Popen(
-        [sys.executable, "-m", "venv", "--symlinks", "--without-pip", "--clear", args.venv_dir]
+        [python_exec, "-m", "venv", "--symlinks", "--without-pip", "--clear", args.venv_dir]
     )
 
     # Find all libraries.

--- a/src/cmake_utils/gen_venv.py
+++ b/src/cmake_utils/gen_venv.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from argparse import ArgumentParser
 from typing import Dict, List
 
@@ -101,18 +102,15 @@ def main():
     shutil.rmtree(args.site_dir, ignore_errors=True)
     os.makedirs(args.site_dir)
 
-    # Find python.
-    lookup_paths = [
-        "/usr/bin",
-        "/usr/local/bin",
-    ]
-    python_exec = shutil.which(args.python, path=":".join(lookup_paths))
+    if sys.executable is None:
+        raise "Unable to determine Python executable path."
+
     # Prepare an empty virtual environment in the background.
     # --symlinks prefers symlinks of copying.
     # --without-pip installs a completely empty venv, with no pip.
     # --clear clears the old venv if exists.
     venv_proc = subprocess.Popen(
-        [python_exec, "-m", "venv", "--symlinks", "--without-pip", "--clear", args.venv_dir]
+        [sys.executable, "-m", "venv", "--symlinks", "--without-pip", "--clear", args.venv_dir]
     )
 
     # Find all libraries.


### PR DESCRIPTION
This PR fixes build scripts to run in environments where Python is not installed globally. This is rather frequent case due to popularity of Python virtual environments and version managers such as `pyenv` or ASDF.