### PR TITLE
Initial syntax for For loops

### DIFF
--- a/src/starkware/cairo/lang/compiler/ast/code_elements.py
+++ b/src/starkware/cairo/lang/compiler/ast/code_elements.py
@@ -12,6 +12,7 @@ from starkware.cairo.lang.compiler.ast.expr import (
     ExprHint,
     ExprIdentifier,
 )
+from starkware.cairo.lang.compiler.ast.for_loop import ForClauseIn
 from starkware.cairo.lang.compiler.ast.formatting_utils import (
     INDENTATION,
     LocationField,
@@ -584,6 +585,31 @@ class CodeElementIf(CodeElement):
 
     def get_children(self) -> Sequence[Optional[AstNode]]:
         return [self.condition, self.main_code_block, self.else_code_block]
+
+
+@dataclasses.dataclass
+class CodeElementFor(CodeElement):
+    clause: ForClauseIn
+    code_block: CodeBlock
+    location: Optional[Location] = LocationField
+
+    def get_children(self) -> Sequence[Optional[AstNode]]:
+        return [self.clause, self.code_block]
+
+    def format(self, allowed_line_length):
+        clauses_particles = ["for ", *self.clause.get_particles()]
+        clauses_particles[-1] += ":"
+        code = particles_in_lines(
+            particles=clauses_particles,
+            config=ParticleFormattingConfig(
+                allowed_line_length=allowed_line_length, line_indent=INDENTATION
+            ),
+        )
+        main_code = self.code_block.format(allowed_line_length=allowed_line_length - INDENTATION)
+        main_code = indent(main_code, INDENTATION)
+        code += f"\n{main_code}"
+        code += "end"
+        return code
 
 
 class Directive(AstNode):

--- a/src/starkware/cairo/lang/compiler/ast/for_loop.py
+++ b/src/starkware/cairo/lang/compiler/ast/for_loop.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Sequence, Optional
+
+from starkware.cairo.lang.compiler.ast.expr import ExprIdentifier, Expression
+from starkware.cairo.lang.compiler.ast.node import AstNode
+from starkware.python.expression_string import ExpressionString
+
+
+@dataclass
+class ForGeneratorRange(Expression):
+    start: Optional[Expression]
+    end: Expression
+    step: Optional[Expression]
+
+    def get_children(self) -> Sequence[Optional[AstNode]]:
+        return self.get_arguments()
+
+    def get_arguments(self) -> Sequence[Expression]:
+        args = []
+
+        if self.start is not None:
+            args.append(self.start)
+
+        args.append(self.end)
+
+        if self.step is not None:
+            args.append(self.step)
+
+        return args
+
+    def to_expr_str(self) -> ExpressionString:
+        # TODO: Better line breaking for arguments
+        args = ", ".join([child.format() for child in self.get_arguments()])
+        return ExpressionString.highest(f"range({args})")
+
+
+@dataclass
+class ForClauseIn(AstNode):
+    identifier: ExprIdentifier
+    generator: ForGeneratorRange
+
+    def get_children(self) -> Sequence[Optional[AstNode]]:
+        return [self.identifier, self.generator]
+
+    def get_particles(self):
+        return [f"{self.identifier.format()} in ", self.generator.format()]

--- a/src/starkware/cairo/lang/compiler/cairo.ebnf
+++ b/src/starkware/cairo/lang/compiler/cairo.ebnf
@@ -125,6 +125,11 @@ _funcdecl: "func" identifier_def implicit_arguments _arguments _NEWLINE* _return
 _func: decorator_list _funcdecl _NEWLINE code_block "end"
 _if: "if" bool_expr ":" _NEWLINE code_block ("else" ":" _NEWLINE code_block)? "end"
 
+// For loops
+for_generator: "range" "(" comma_separated_with_notes{expr} ")" -> for_generator_range
+for_clause: identifier_def "in" for_generator -> for_clause_in
+_for: "for" for_clause ":" _NEWLINE code_block "end"
+
 !_some_namespace: "struct" | "namespace"
 _struct: decorator_list _some_namespace identifier_def ":"_NEWLINE code_block "end"
 
@@ -150,6 +155,7 @@ code_element: instruction                                       -> code_element_
             | "return" "(" arg_list ")"                         -> code_element_return
             | "return" function_call                            -> code_element_tail_call
             | _if                                               -> code_element_if
+            | _for                                              -> code_element_for
             | function_call                                     -> code_element_func_call
             | identifier ":"                                    -> code_element_label
             | _func                                             -> code_element_function

--- a/src/starkware/cairo/lang/compiler/parser_test.py
+++ b/src/starkware/cairo/lang/compiler/parser_test.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from typing import List
 
 import pytest
@@ -11,6 +12,7 @@ from starkware.cairo.lang.compiler.ast.cairo_types import (
     TypeTuple,
 )
 from starkware.cairo.lang.compiler.ast.code_elements import (
+    CodeElementFor,
     CodeElementImport,
     CodeElementReference,
     CodeElementReturnValueReference,
@@ -918,3 +920,18 @@ def test_pointer():
     for typ, mark in safe_zip(types, marks):
         assert typ.location is not None
         assert get_location_marks(code, typ.location) == code + "\n" + mark
+
+
+def test_for():
+    source = dedent("""
+    for i in range(5):
+        f()
+    end
+    """).strip()
+
+    res = parse_code_element(source)
+    assert isinstance(res, CodeElementFor)
+    assert res.format(allowed_line_length=100) == source
+
+# TODO: Tests with start & step arguments
+# TODO: Test with expressions as arguments


### PR DESCRIPTION
This PR adds initial syntax for `for` loops into the Cairo language. Current focus is to get support of loops with 1 `range` generator without any accumulating logic and other neat features we plan to introduce later.

Examples:

```python
# Range iteration with constant literal
for i in range(5):
	[ap] = i; ap++
end

# Range iteration with expressions
local l = 5
for i in range(l):
	[ap] = i; ap++
end

# Backward range iteration with steps
for i in range(10, 0, -1):
	foo(i)
end
```

cc @liorgold2