### PR TITLE
Improve documentation for uint256_eq

### DIFF
--- a/src/starkware/cairo/common/uint256.cairo
+++ b/src/starkware/cairo/common/uint256.cairo
@@ -293,7 +293,7 @@ end
 
 # Bitwise.
 
-# Return true if both integers are equal.
+# Return 1 if both integers are equal.
 func uint256_eq{range_check_ptr}(a : Uint256, b : Uint256) -> (res):
     if a.high != b.high:
         return (0)


### PR DESCRIPTION
I updated the documentation because this function returns `0` or `1`. As far as I can tell, Cairo doesn't have boolean types so `true` is represented by `1` and `false` is `0`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/50)
<!-- Reviewable:end -->
