### PR TITLE
Fix several resource warnings: unclosed file

### DIFF
--- a/src/cmake_utils/gen_pip_cmake.py
+++ b/src/cmake_utils/gen_pip_cmake.py
@@ -13,6 +13,7 @@ import json
 import os
 from argparse import ArgumentParser
 from collections import defaultdict
+from pathlib import Path
 
 
 def main():
@@ -63,8 +64,9 @@ python_pip(pip_{package_name}
 
     # Write the output file, only if it is changed, so that the timestamp will not be updated
     # otherwise.
-    if not os.path.exists(args.output) or open(args.output, "r").read() != res:
-        open(args.output, "w").write(res)
+    output = Path(args.output)
+    if not output.exists() or output.read_text() != res:
+        output.write_text(res)
 
 
 if __name__ == "__main__":

--- a/src/cmake_utils/gen_python_exe.py
+++ b/src/cmake_utils/gen_python_exe.py
@@ -30,7 +30,8 @@ def main():
     )
     args = parser.parse_args()
 
-    venv_info = json.load(open(os.path.join(args.info_dir, f"{args.venv}.info")))
+    with open(os.path.join(args.info_dir, f"{args.venv}.info")) as fp:
+        venv_info = json.load(fp)
     # Fetch the location of the venv dir, relative to the executable script.
     build_path_bash = os.path.relpath(args.cmake_binary_dir, os.path.dirname(args.exe_path))
     assert (

--- a/src/starkware/cairo/bootloaders/fact_topology.py
+++ b/src/starkware/cairo/bootloaders/fact_topology.py
@@ -22,7 +22,8 @@ class FactTopologiesFile:
 
 
 def load_fact_topologies(path) -> List[FactTopology]:
-    return FactTopologiesFile.Schema().load(json.load(open(path))).fact_topologies
+    with open(path) as fp:
+        return FactTopologiesFile.Schema().load(json.load(fp)).fact_topologies
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/starkware/cairo/bootloaders/program_hash_test_utils.py
+++ b/src/starkware/cairo/bootloaders/program_hash_test_utils.py
@@ -5,7 +5,8 @@ from starkware.cairo.lang.compiler.program import Program
 
 
 def run_generate_hash_test(fix: bool, program_path: str, hash_path: str, command: str):
-    compiled_program = Program.Schema().load(json.load(open(program_path)))
+    with open(program_path) as fp:
+        compiled_program = Program.Schema().load(json.load(fp))
     program_hash = hex(compute_program_hash_chain(program=compiled_program))
     program_hash_key = "program_hash"
 
@@ -14,7 +15,8 @@ def run_generate_hash_test(fix: bool, program_path: str, hash_path: str, command
             fp.write(json.dumps({program_hash_key: program_hash}, indent=4) + "\n")
         return
 
-    expected_hash = json.load(open(hash_path))[program_hash_key]
+    with open(hash_path) as fp:
+        expected_hash = json.load(fp)[program_hash_key]
     assert expected_hash == program_hash, (
         f"Wrong program hash in program_hash.json. Found: {program_hash}. "
         f"Expected: {expected_hash}. Please run {command}."

--- a/src/starkware/cairo/lang/compiler/cairo_format.py
+++ b/src/starkware/cairo/lang/compiler/cairo_format.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+from pathlib import Path
 
 from starkware.cairo.lang.compiler.ast.formatting_utils import set_one_item_per_line
 from starkware.cairo.lang.compiler.parser import parse_file
@@ -35,7 +36,7 @@ def main():
 
     with set_one_item_per_line(args.one_item_per_line):
         for path in args.files:
-            old_content = open(path).read() if path != "-" else sys.stdin.read()
+            old_content = Path(path).read_text() if path != "-" else sys.stdin.read()
             try:
                 new_content = parse_file(
                     old_content, filename="<input>" if path == "-" else path
@@ -46,7 +47,7 @@ def main():
 
             if args.inplace:
                 assert path != "-", 'Using "-i" together with "-" is not supported.'
-                open(path, "w").write(new_content)
+                Path(path).write_text(new_content)
             elif args.check:
                 assert path != "-", 'Using "-c" together with "-" is not supported.'
                 if old_content != new_content:

--- a/src/starkware/cairo/lang/compiler/error_handling.py
+++ b/src/starkware/cairo/lang/compiler/error_handling.py
@@ -17,7 +17,8 @@ class InputFile:
         """
         if self.content is None:
             assert self.filename is not None, "Content must be set if filename is None."
-            self.content = open(self.filename, "r").read()
+            with open(self.filename) as fp:
+                self.content = fp.read()
 
         return self.content
 

--- a/src/starkware/cairo/lang/compiler/parser.py
+++ b/src/starkware/cairo/lang/compiler/parser.py
@@ -18,8 +18,10 @@ from starkware.cairo.lang.compiler.parser_transformer import (
 )
 
 grammar_file = os.path.join(os.path.dirname(__file__), "cairo.ebnf")
+with open(grammar_file, "r") as fp:
+    content = fp.read()
 gram_parser = lark.Lark(
-    open(grammar_file, "r").read(),
+    content,
     start=[
         "cairo_file",
         "code_block",

--- a/src/starkware/cairo/lang/setup.py
+++ b/src/starkware/cairo/lang/setup.py
@@ -3,9 +3,12 @@ import os.path
 import setuptools
 
 DIR = os.path.abspath(os.path.dirname(__file__))
-requirements = open(os.path.join(DIR, "requirements.txt")).read().splitlines()
-version = open(os.path.join(DIR, "starkware/cairo/lang/VERSION")).read().strip()
-long_description = open("README.md", "r", encoding="utf-8").read()
+with open(os.path.join(DIR, "requirements.txt")) as fp:
+    requirements = fp.read().splitlines()
+with open(os.path.join(DIR, "starkware/cairo/lang/VERSION")) as fp:
+    version = fp.read().strip()
+with open("README.md", encoding="utf-8") as fp:
+    long_description = fp.read()
 
 setuptools.setup(
     name="cairo-lang",

--- a/src/starkware/cairo/lang/tracer/tracer_data.py
+++ b/src/starkware/cairo/lang/tracer/tracer_data.py
@@ -202,23 +202,23 @@ class TracerData:
         """
         Factory method constructing TracerData from files.
         """
-        program = Program.load(data=json.load(open(program_path)))
+        with open(program_path) as fp:
+            program = Program.load(data=json.load(fp))
         field_bytes = math.ceil(program.prime.bit_length() / 8)
         memory = read_memory(memory_path, field_bytes)
         trace = read_trace(trace_path)
         program_base = PROGRAM_BASE
 
         # Read AIR public input, if available and extract public memory addresses.
+        public_input = None
         if air_public_input is not None:
-            public_input = PublicInput.Schema().load(json.load(open(air_public_input)))
-        else:
-            public_input = None
+            with open(air_public_input) as fp:
+                public_input = PublicInput.Schema().load(json.load(fp))
 
-        debug_info = (
-            DebugInfo.load(data=json.load(open(debug_info_path)))
-            if debug_info_path is not None
-            else None
-        )
+        debug_info = None
+        if debug_info_path is not None:
+            with open(debug_info_path) as fp:
+                debug_info = DebugInfo.load(data=json.load(fp))
 
         # Construct the instance.
         return cls(

--- a/src/starkware/cairo/lang/version.py
+++ b/src/starkware/cairo/lang/version.py
@@ -1,3 +1,4 @@
 import os
 
-__version__ = open(os.path.join(os.path.dirname(__file__), "VERSION")).read().strip()
+with open(os.path.join(os.path.dirname(__file__), "VERSION")) as fp:
+    __version__ = fp.read().strip()

--- a/src/starkware/cairo/lang/vm/cairo_pie.py
+++ b/src/starkware/cairo/lang/vm/cairo_pie.py
@@ -237,7 +237,7 @@ class CairoPie:
 
         verify_zip_file_prefix(fileobj=fileobj)
 
-        with zipfile.ZipFile(fileobj) as zf:
+        with fileobj, zipfile.ZipFile(fileobj) as zf:
             cls.verify_zip_format(zf)
 
             with zf.open(cls.METADATA_FILENAME, "r") as fp:

--- a/src/starkware/cairo/lang/vm/reconstruct_traceback.py
+++ b/src/starkware/cairo/lang/vm/reconstruct_traceback.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import re
 import sys
+from pathlib import Path
 
 from starkware.cairo.lang.compiler.program import Program
 from starkware.cairo.lang.version import __version__
@@ -56,13 +57,17 @@ def main():
         0 if args.contract is None else 1
     ) == 1, "Exactly one of --program, --contract must be specified."
     if args.program is not None:
-        program_json = json.load(open(args.program))
+        program_json = json.loads(Path(args.program).read_text())
     else:
         assert args.contract is not None
-        program_json = json.load(open(args.contract))["program"]
+        program_json = json.loads(Path(args.contract).read_text())["program"]
 
     program = Program.load(program_json)
-    traceback = (open(args.traceback) if args.traceback != "-" else sys.stdin).read()
+    traceback = (
+        Path(args.traceback).read_text()
+        if args.traceback != "-"
+        else sys.stdin.read()
+    )
 
     print(reconstruct_traceback(program, traceback))
     return 0

--- a/src/starkware/cairo/sharp/sharp_client.py
+++ b/src/starkware/cairo/sharp/sharp_client.py
@@ -58,7 +58,8 @@ class SharpClient:
                 ]
                 + used_flags
             )
-            program = Program.load(data=json.load(open(compiled_program_file.name, "r")))
+            with open(compiled_program_file.name) as fp:
+                program = Program.load(data=json.load(fp))
         return program
 
     def run_program(self, program: Program, program_input_path: Optional[str]) -> CairoPie:
@@ -199,7 +200,8 @@ def submit(args, command_args):
         cairo_pie = CairoPie.from_file(args.cairo_pie)
     else:
         if args.program is not None:
-            program = Program.load(data=json.load(open(args.program)))
+            with open(args.program) as fp:
+                program = Program.load(data=json.load(fp))
         else:
             assert args.source is not None
             print("Compiling...", file=sys.stderr)

--- a/src/starkware/crypto/starkware/crypto/signature/nothing_up_my_sleeve_gen.py
+++ b/src/starkware/crypto/starkware/crypto/signature/nothing_up_my_sleeve_gen.py
@@ -24,6 +24,7 @@ The output of this file is kept in 'pedersen_params.json', and 'signature.py' us
 import json
 import math
 import os
+from pathlib import Path
 
 from math_utils import ec_double, is_quad_residue, pi_as_string, sqrt_mod
 
@@ -125,7 +126,7 @@ AUTO_GENERATED_STRING = "The following data was auto-generated. PLEASE DO NOT ED
 
 # Write generated parameters to file.
 PEDERSEN_HASH_POINT_FILENAME = os.path.join(os.path.dirname(__file__), "pedersen_params.json")
-open(PEDERSEN_HASH_POINT_FILENAME, "w").write(
+Path(PEDERSEN_HASH_POINT_FILENAME, "w").write_text(
     json.dumps(
         {
             "_license": COPYRIGHT_STRING.splitlines(),

--- a/src/starkware/crypto/starkware/crypto/signature/signature.py
+++ b/src/starkware/crypto/starkware/crypto/signature/signature.py
@@ -34,7 +34,8 @@ from starkware.crypto.signature.math_utils import (
 )
 
 PEDERSEN_HASH_POINT_FILENAME = os.path.join(os.path.dirname(__file__), "pedersen_params.json")
-PEDERSEN_PARAMS = json.load(open(PEDERSEN_HASH_POINT_FILENAME))
+with open(PEDERSEN_HASH_POINT_FILENAME) as fp:
+    PEDERSEN_PARAMS = json.load(fp)
 
 FIELD_PRIME = PEDERSEN_PARAMS["FIELD_PRIME"]
 FIELD_GEN = PEDERSEN_PARAMS["FIELD_GEN"]

--- a/src/starkware/starknet/business_logic/execution/os_usage.py
+++ b/src/starkware/starknet/business_logic/execution/os_usage.py
@@ -18,9 +18,8 @@ class OsResources(ValidatedMarshmallowDataclass):
 
 
 # Empirical costs; accounted during transaction execution.
-os_resources: OsResources = OsResources.loads(
-    data=open(os.path.join(DIR, "os_resources.json")).read()
-)
+with open(os.path.join(DIR, "os_resources.json")) as fp:
+    os_resources: OsResources = OsResources.loads(data=fp.read())
 
 
 def calculate_syscall_resources(syscall_counter: Mapping[str, int]) -> ExecutionResources:

--- a/src/starkware/starknet/cli/starknet_cli.py
+++ b/src/starkware/starknet/cli/starknet_cli.py
@@ -594,7 +594,8 @@ async def tx_status(args, command_args):
                 else:
                     addr_str, path = addr_and_path_split
                     addr = parse_address(addr_str)
-                contracts[addr] = Program.load(json.load(open(path.strip()))["program"])
+                with open(path.strip()) as fp:
+                    contracts[addr] = Program.load(json.load(fp)["program"])
             error_message = reconstruct_starknet_traceback(
                 contracts=contracts, traceback_txt=error_message
             )

--- a/src/starkware/starknet/core/os/os_config/os_config_hash_test.py
+++ b/src/starkware/starknet/core/os/os_config/os_config_hash_test.py
@@ -79,7 +79,8 @@ def run_starknet_os_config_hash_test(fix: bool):
             fp.write(json.dumps(config_hashes, indent=4) + "\n")
         return
 
-    expected_hashes = json.load(open(HASH_PATH))
+    with open(HASH_PATH) as fp:
+        expected_hashes = json.load(fp)
     for config_name, computed_hash in config_hashes.items():
         expected_hash = expected_hashes[config_name]
         assert expected_hash == computed_hash, (

--- a/src/starkware/starknet/third_party/open_zeppelin/starknet_contracts.py
+++ b/src/starkware/starknet/third_party/open_zeppelin/starknet_contracts.py
@@ -4,4 +4,5 @@ from starkware.starknet.services.api.contract_definition import ContractDefiniti
 
 DIR = os.path.dirname(__file__)
 
-account_contract = ContractDefinition.loads(open(os.path.join(DIR, "account.json")).read())
+with open(os.path.join(DIR, "account.json")) as fp:
+    account_contract = ContractDefinition.loads(fp).read()

--- a/src/starkware/starknet/wallets/open_zeppelin.py
+++ b/src/starkware/starknet/wallets/open_zeppelin.py
@@ -46,7 +46,8 @@ class OpenZeppelinAccount(Account):
         if os.path.exists(self.account_file):
             # Make a backup of the file.
             shutil.copy(self.account_file, self.account_file + ".backup")
-            accounts = json.load(open(self.account_file))
+            with open(self.account_file) as fp:
+                accounts = json.load(fp)
         else:
             accounts = {}
 
@@ -115,7 +116,8 @@ Transaction hash: {gateway_response['transaction_hash']}
             "Did you deploy your account contract (using 'starnet deploy_account')?"
         )
 
-        accounts = json.load(open(self.account_file))
+        with open(self.account_file) as fp:
+            accounts = json.load(fp)
         accounts_for_network = accounts.get(self.starknet_context.network_id, {})
         if self.account_name not in accounts_for_network:
             raise AccountNotFoundException(

--- a/src/starkware/starkware_utils/config_base.py
+++ b/src/starkware/starkware_utils/config_base.py
@@ -23,7 +23,8 @@ def load_config(
     if config_file_path is None:
         config_file_path = "/config.yml"
 
-    config = yaml.safe_load(open(config_file_path, "r"))
+    with open(config_file_path) as fp:
+        config = yaml.safe_load(fp)
     if load_logging_config:
         logging.config.dictConfig(config.get("LOGGING", {}))
 


### PR DESCRIPTION
There were a lot of warnings, they should now be gone :)

Sometimes I am using the `pathlib` when it would be too verbose to use the context manager (typically code in a comprehension list/tuple).

---

In another PR, and if you are OK with that, I would like to uniform all paths reads/writes. WDYT?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/58)
<!-- Reviewable:end -->
