### PR TITLE
Upgrade frozendict to 2.3.2

### DIFF
--- a/scripts/requirements-deps.json
+++ b/scripts/requirements-deps.json
@@ -405,7 +405,7 @@
     {
         "dependencies": [],
         "package": {
-            "installed_version": "1.2",
+            "installed_version": "2.3.2",
             "key": "frozendict",
             "package_name": "frozendict"
         }

--- a/scripts/requirements-gen.txt
+++ b/scripts/requirements-gen.txt
@@ -3,7 +3,7 @@ cachetools
 ecdsa
 eth-hash[pycryptodome]
 fastecdsa
-frozendict==1.2
+frozendict==2.3.2
 lark-parser
 marshmallow-dataclass>=7.1.0
 marshmallow-enum

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -21,7 +21,7 @@ eth-rlp==0.2.1
 eth-typing==2.3.0
 eth-utils==1.10.0
 fastecdsa==2.2.3
-frozendict==1.2
+frozendict==2.3.2
 frozenlist==1.3.0
 hexbytes==0.2.2
 idna==3.3


### PR DESCRIPTION
It fixes the `AttributeError` issue on Python 3.10, and should improve performances (as it is said on their changelog).

Fixes #27.
Fixes #38.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/59)
<!-- Reviewable:end -->
