### PR TITLE
Add ´is_even(value, rc_bound)´ function to ´math_utils.py´

### DIFF
--- a/src/starkware/cairo/common/math_utils.py
+++ b/src/starkware/cairo/common/math_utils.py
@@ -24,11 +24,13 @@ def is_positive(value, prime, rc_bound):
     assert abs(val) < rc_bound, f"value={val} is out of the valid range."
     return val > 0
 
-def is_even(value, rc_bound):
+
+def is_even(value, prime, rc_bound):
     """
-    Returns true if the input is even and within the range (-rc_bound, rc_bound).
-    Raises an exception if the element is not within the accepted range.
+    Returns True if the lift of the given field element, as an integer in the range
+    (-rc_bound, rc_bound), is even.
+    Raises an exception if the element is not within that range.
     """
-    assert_integer(value)
-    assert abs(value) < rc_bound, f"value={value} is out of the valid range."
-    return value % 2 == 0
+    val = as_int(value, prime)
+    assert abs(val) < rc_bound, f"value={val} is out of the valid range."
+    return val % 2 == 0

--- a/src/starkware/cairo/common/math_utils.py
+++ b/src/starkware/cairo/common/math_utils.py
@@ -23,3 +23,12 @@ def is_positive(value, prime, rc_bound):
     val = as_int(value, prime)
     assert abs(val) < rc_bound, f"value={val} is out of the valid range."
     return val > 0
+
+def is_even(value, rc_bound):
+    """
+    Returns true if the input is even and within the range (-rc_bound, rc_bound).
+    Raises an exception if the element is not within the accepted range.
+    """
+    assert_integer(value)
+    assert abs(value) < rc_bound, f"value={value} is out of the valid range."
+    return value % 2 == 0


### PR DESCRIPTION
Hey, looking to contribute and find this a necessity.

## Description
Add a function that allows checking if a value is even.

## Why?
Existing functions like [`merkle_update`](https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/common/merkle_update.cairo#L47) could benefit from such a check. Further functions (I am creating one to calculate the median value of an array) could benefit from distinguishing between even and odd values easily.

## What
Created `is_even(value, rc_bound)` which allows:
* asserts value is an integer
* asserts value is within the (-rc_bound, rc_bound) range
* returns true if value is even

## Who could review?
Thank you and please let me know if any change is required.

@glrn @l-henri @liorgold2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/65)
<!-- Reviewable:end -->
