### PR TITLE
Add array operations to cairo functions

### DIFF
--- a/src/starkware/cairo/common/array_operations.cairo
+++ b/src/starkware/cairo/common/array_operations.cairo
@@ -4,113 +4,113 @@ from starkware.cairo.common.alloc import alloc
 
 # Compute the sum of the element in an array.
 # Args:
-#   n - length of the felt array.
-#   vs - felt array.
+#   input_len - length of the felt array.
+#   input - felt array.
 # Returns:
-#   s - felt with the sum of each element of the array.
-func sum(n: felt, vs : felt*) -> (s : felt):
-    if n == 0:
-        return(s=0)
+#   output - felt with the sum of each element of the array.
+func sum(input_len : felt, input : felt*) -> (output : felt):
+    if input_len == 0:
+        return(0)
     end
-    let (s) = sum(n = n-1, vs = vs + 1) 
-    return(s + [vs])
+    let (output) = sum(input_len - 1, input + 1) 
+    return(output + [input])
 end
 
 # Compute the arithmetic mean along the array.
 # Args:
-#   n - length of the felt array.
-#   vs - felt array.
+#   input_len - length of the felt array.
+#   input - felt array.
 # Returns:
-#   m - arithmetic mean.
-func mean(n : felt, vs : felt*) -> (m : felt):
-    let (s) = sum(n = n, vs = vs)
-    return(s / n)
+#   output - arithmetic mean.
+func mean(input_len : felt, input : felt*) -> (output : felt):
+    let (s) = sum(input_len, input)
+    return(s / input_len)
 end
 
 # Compute the scalar multiplication of an array.
 # Args:
-#   n - length of the felt array.
+#   input_len - length of the felt array.
 #   scalar - felt that multiplies the array.
-#   vs - felt array.
+#   input - felt array.
 # Returns:
-#   d - scalar product felt.
-func scalar_product(n : felt, scalar : felt, vs : felt*) -> (d : felt):    
-    if n == 0:
-        return(d=0)
+#   output - scalar product felt.
+func scalar_product(input_len : felt, scalar : felt, input : felt*) -> (output : felt):    
+    if input_len == 0:
+        return(0)
     end
-    let (d) = scalar_product(n-1, scalar, vs + 1)
-    return (scalar * [vs] + d) 
+    let (d) = scalar_product(input_len - 1, scalar, input + 1)
+    return (scalar * [input] + d) 
 end
 
 # Compute the median along the array.
 # Args:
-#   n - length of the felt array.
+#   input_len - length of the felt array.
 #   vs - felt array.
 # Returns:
-#   m - median.
-func median(n : felt, vs : felt*) -> (med : felt):
+#   output - median.
+func median(input_len : felt, input : felt*) -> (med : felt):
     tempvar is_even : felt
     %{
-        ids.is_even = 1 if (ids.n % 2 == 0) else 0
+        ids.is_even = 1 if (ids.input_len % 2 == 0) else 0
     %}
     if is_even == 1:
-        return(vs[n/2])
+        return(input[input_len / 2])
     else:
-        tempvar a = vs[((n-1)/2)-1]
-        tempvar b = vs[((n+1)/2)-1]
-        return((a+b)/2)
+        tempvar a = input[((input_len - 1) / 2) - 1]
+        tempvar b = input[((input_len + 1) / 2) - 1]
+        return((a + b) / 2)
     end
 end
 
 # Compute the dot product of two arrays.
 # Args:
-#   n - length of the felt arrays. If they do not have the same length an error will appear.
-#   vs1 - first felt array.
-#   vs2 - second felt array.
+#   input_len - length of the felt arrays. If they do not have the same length an error will appear.
+#   input1 - first felt array.
+#   input2 - second felt array.
 # Returns:
-#   d - dot product felt.
-func dot(n : felt, vs1 : felt*, vs2 : felt*) -> (d : felt):    
-    if n == 1:
-        return(d=0)
+#   output - dot product felt.
+func dot(input_len : felt, input1 : felt*, input2 : felt*) -> (output : felt):    
+    if input_len == 1:
+        return(0)
     end
-    let (d) = dot(n-1, vs1 + 1, vs2 + 1)
-    return ([vs1] * [vs2] + d) 
+    let (d) = dot(input_len - 1, input1 + 1, input2 + 1)
+    return ([input1] * [input2] + d) 
 end
 
 # Obtain the minimum value in an array.
 # Args:
-#   n - length of the felt array.
-#   vs - felt array.
+#   input_len - length of the felt array.
+#   input - felt array.
 # Returns:
-#   m - minimum value.
-func min(n : felt, vs : felt*) -> (m : felt):
-    if n == 0:
-        return (vs[0])
+#   output - minimum value.
+func min(input_len : felt, input : felt*) -> (output : felt):
+    if input_len == 0:
+        return (input[0])
     end
-    let (n_prev) = min(n-1, vs)
-    let min_prev = vs[n-1]
-    tempvar m : felt
+    let (input_len_prev) = min(input_len - 1, input)
+    let min_prev = input[input_len - 1]
+    tempvar output : felt
     %{
-        ids.m = min(ids.n_prev, ids.min_prev)
+        ids.output = min(ids.input_len_prev, ids.min_prev)
     %}
-    return(m)
+    return(output)
 end
 
 # Obtain the maximum value in an array.
 # Args:
-#   n - length of the felt array.
-#   vs - felt array.
+#   input_len - length of the felt array.
+#   input - felt array.
 # Returns:
-#   m - maximum value.
-func max(n : felt, vs : felt*) -> (m : felt):
-    if n == 0:
-        return (vs[0])
+#   output - maximum value.
+func max(input_len : felt, input : felt*) -> (output : felt):
+    if input_len == 0:
+        return (input[0])
     end
-    let (n_prev) = max(n-1, vs)
-    let max_prev = vs[n-1]
-    tempvar m : felt
+    let (input_len_prev) = max(input_len - 1, input)
+    let max_prev = input[input_len - 1]
+    tempvar output : felt
     %{
-        ids.m = max(ids.n_prev, ids.max_prev)
+        ids.output = max(ids.input_len_prev, ids.max_prev)
     %}
-    return(m)
+    return(output)
 end

--- a/src/starkware/cairo/common/array_operations.cairo
+++ b/src/starkware/cairo/common/array_operations.cairo
@@ -1,0 +1,116 @@
+# Library to implement array operations.
+
+from starkware.cairo.common.alloc import alloc
+
+# Compute the sum of the element in an array.
+# Args:
+#   n - length of the felt array.
+#   vs - felt array.
+# Returns:
+#   s - felt with the sum of each element of the array.
+func sum(n: felt, vs : felt*) -> (s : felt):
+    if n == 0:
+        return(s=0)
+    end
+    let (s) = sum(n = n-1, vs = vs + 1) 
+    return(s + [vs])
+end
+
+# Compute the arithmetic mean along the array.
+# Args:
+#   n - length of the felt array.
+#   vs - felt array.
+# Returns:
+#   m - arithmetic mean.
+func mean(n : felt, vs : felt*) -> (m : felt):
+    let (s) = sum(n = n, vs = vs)
+    return(s / n)
+end
+
+# Compute the scalar multiplication of an array.
+# Args:
+#   n - length of the felt array.
+#   scalar - felt that multiplies the array.
+#   vs - felt array.
+# Returns:
+#   d - scalar product felt.
+func scalar_product(n : felt, scalar : felt, vs : felt*) -> (d : felt):    
+    if n == 0:
+        return(d=0)
+    end
+    let (d) = scalar_product(n-1, scalar, vs + 1)
+    return (scalar * [vs] + d) 
+end
+
+# Compute the median along the array.
+# Args:
+#   n - length of the felt array.
+#   vs - felt array.
+# Returns:
+#   m - median.
+func median(n : felt, vs : felt*) -> (med : felt):
+    tempvar is_even : felt
+    %{
+        ids.is_even = 1 if (ids.n % 2 == 0) else 0
+    %}
+    if is_even == 1:
+        return(vs[n/2])
+    else:
+        tempvar a = vs[((n-1)/2)-1]
+        tempvar b = vs[((n+1)/2)-1]
+        return((a+b)/2)
+    end
+end
+
+# Compute the dot product of two arrays.
+# Args:
+#   n - length of the felt arrays. If they do not have the same length an error will appear.
+#   vs1 - first felt array.
+#   vs2 - second felt array.
+# Returns:
+#   d - dot product felt.
+func dot(n : felt, vs1 : felt*, vs2 : felt*) -> (d : felt):    
+    if n == 1:
+        return(d=0)
+    end
+    let (d) = dot(n-1, vs1 + 1, vs2 + 1)
+    return ([vs1] * [vs2] + d) 
+end
+
+# Obtain the minimum value in an array.
+# Args:
+#   n - length of the felt array.
+#   vs - felt array.
+# Returns:
+#   m - minimum value.
+func min(n : felt, vs : felt*) -> (m : felt):
+    if n == 0:
+        return (vs[0])
+    end
+    let (n_prev) = min(n-1, vs)
+    let min_prev = vs[n-1]
+    tempvar m : felt
+    %{
+        ids.m = min(ids.n_prev, ids.min_prev)
+    %}
+    return(m)
+end
+
+# Obtain the maximum value in an array.
+# Args:
+#   n - length of the felt array.
+#   vs - felt array.
+# Returns:
+#   m - maximum value.
+func max(n : felt, vs : felt*) -> (m : felt):
+    if n == 0:
+        return (vs[0])
+    end
+    let (n_prev) = max(n-1, vs)
+    let max_prev = vs[n-1]
+    tempvar m : felt
+    %{
+        ids.m = max(ids.n_prev, ids.max_prev)
+    %}
+    return(m)
+end

--- a/src/starkware/cairo/common/math_utils.py
+++ b/src/starkware/cairo/common/math_utils.py
@@ -23,3 +23,12 @@ def is_positive(value, prime, rc_bound):
     val = as_int(value, prime)
     assert abs(val) < rc_bound, f"value={val} is out of the valid range."
     return val > 0
+
+def is_even(value, rc_bound):
+    """
+    Returns true if the input is even and within the range (-rc_bound, rc_bound).
+    Raises an exception if the element is not within the accepted range.
+    """
+    assert_integer(value)
+    assert abs(value) < rc_bound, f"value={value} is out of the valid range."
+    return value % 2 == 0


### PR DESCRIPTION
DRAFT - PLEASE DO NOT REVIEW YET

Hey! This is the main submission of @haycarlitos and @omarespejel to the Miami Activate Hackathon. We are aiming to solve an infrastructure necessity for the Starknet ecosystem.

## Description
Add array operations in Cairo.

## Why
Development of programs involving vector operations require a set of numerical operations currently non-existing in the Cairo stack.

## What?
    * sum - Compute the sum of the element in an array.
    * mean - Compute the arithmetic mean along the array.
    * scalar_product - Compute the scalar multiplication of an array.
    * median - Compute the median along the array.
    * dot - Compute the dot product of two arrays.
    * min - Obtain the minimum value in an array.
    * max - Obtain the maximum value in an array.

## Who could review?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/66)
<!-- Reviewable:end -->
