### PR TITLE
Add commentary syntax for Vim plugin

### DIFF
--- a/src/starkware/cairo/lang/ide/vim/ftplugin/cairo.vim
+++ b/src/starkware/cairo/lang/ide/vim/ftplugin/cairo.vim
@@ -4,3 +4,6 @@ setlocal tabstop=4
 setlocal shiftwidth=4
 
 command -buffer Format !.tox/dev/bin/python cairo-format -i %
+
+" Set '#' as commentary
+autocmd FileType cairo setlocal commentstring=#\ %s


### PR DESCRIPTION
Allow to use plugin 'tpope/vim-commentary' to fast comment lines in cairo files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/87)
<!-- Reviewable:end -->
