### PR TITLE
Bump lark-parser to latest version

### DIFF
--- a/scripts/requirements-gen.txt
+++ b/scripts/requirements-gen.txt
@@ -4,7 +4,7 @@ ecdsa
 eth-hash[pycryptodome]
 fastecdsa
 frozendict==1.2
-lark-parser
+lark
 marshmallow-dataclass>=7.1.0
 marshmallow-enum
 marshmallow-oneofschema

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -25,7 +25,7 @@ idna==3.3
 iniconfig==1.1.1
 ipfshttpclient==0.8.0a2
 jsonschema==3.2.0
-lark-parser==0.12.0
+lark==1.1.2
 lru-dict==1.1.8
 marshmallow==3.17.1
 marshmallow-dataclass==8.5.8

--- a/src/starkware/cairo/lang/compiler/parser.py
+++ b/src/starkware/cairo/lang/compiler/parser.py
@@ -30,7 +30,7 @@ def get_grammar_parser(grammar: str) -> lark.Lark:
             "type",
             "typed_identifier",
         ],
-        lexer="standard",
+        lexer="basic",
         parser="lalr",
         propagate_positions=True,
     )

--- a/src/starkware/cairo/lang/compiler/parser_transformer.py
+++ b/src/starkware/cairo/lang/compiler/parser_transformer.py
@@ -178,7 +178,7 @@ class ParserTransformer(Transformer):
     # Types.
 
     @v_args(meta=True)
-    def named_type(self, value, meta) -> TypeTuple.Item:
+    def named_type(self, meta, value) -> TypeTuple.Item:
         name: Optional[str]
         if len(value) == 1:
             # Unnamed type.
@@ -202,11 +202,11 @@ class ParserTransformer(Transformer):
         return TypeTuple.Item(name=name, typ=typ, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def type_felt(self, value, meta):
+    def type_felt(self, meta, value):
         return TypeFelt(location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def type_codeoffset(self, value, meta):
+    def type_codeoffset(self, meta, value):
         return TypeCodeoffset(location=self.meta2loc(meta))
 
     def type_struct(self, value):
@@ -224,11 +224,11 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def type_pointer(self, value, meta):
+    def type_pointer(self, meta, value):
         return TypePointer(pointee=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def type_pointer2(self, value, meta):
+    def type_pointer2(self, meta, value):
         location = self.meta2loc(meta)
         inner_location = (
             None
@@ -240,7 +240,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def type_tuple(self, value: Tuple[CommaSeparatedWithNotes], meta):
+    def type_tuple(self, meta, value: Tuple[CommaSeparatedWithNotes]):
         (lst,) = value
         return TypeTuple(
             members=lst.args,
@@ -251,7 +251,7 @@ class ParserTransformer(Transformer):
 
     # Expression.
     @v_args(meta=True)
-    def arg_list(self, value: Tuple[CommaSeparatedWithNotes], meta):
+    def arg_list(self, meta, value: Tuple[CommaSeparatedWithNotes]):
         (lst,) = value
         return ArgList(
             args=lst.args,
@@ -261,7 +261,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def expr_assignment(self, value, meta):
+    def expr_assignment(self, meta, value):
         if len(value) == 1:
             identifier = None
             expr = value[0]
@@ -272,25 +272,25 @@ class ParserTransformer(Transformer):
         return ExprAssignment(identifier=identifier, expr=expr, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def identifier(self, value, meta):
+    def identifier(self, meta, value):
         return ExprIdentifier(name=".".join(x.value for x in value), location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def identifier_def(self, value, meta):
+    def identifier_def(self, meta, value):
         return ExprIdentifier(name=value[0].value, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_number(self, value, meta):
+    def atom_number(self, meta, value):
         return ExprConst(val=int(value[0]), format_str=value[0].value, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_hex_number(self, value, meta):
+    def atom_hex_number(self, meta, value):
         return ExprConst(
             val=int(value[0], 16), format_str=value[0].value, location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def atom_short_string(self, value, meta):
+    def atom_short_string(self, meta, value):
         location = self.meta2loc(meta)
         token_text = value[0].value
         assert token_text[0] == token_text[-1] == "'"
@@ -314,79 +314,79 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def atom_hint(self, value, meta):
+    def atom_hint(self, meta, value):
         return ExprHint.from_str(val=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_reg(self, value, meta):
+    def atom_reg(self, meta, value):
         return ExprReg(reg=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_func_call(self, value, meta):
+    def atom_func_call(self, meta, value):
         return ExprFuncCall(rvalue=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def expr_add(self, value, meta):
+    def expr_add(self, meta, value):
         return ExprOperator(
             a=value[0], op="+", b=value[2], notes=value[1], location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def expr_sub(self, value, meta):
+    def expr_sub(self, meta, value):
         return ExprOperator(
             a=value[0], op="-", b=value[2], notes=value[1], location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def expr_mul(self, value, meta):
+    def expr_mul(self, meta, value):
         return ExprOperator(
             a=value[0], op="*", b=value[2], notes=value[1], location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def expr_div(self, value, meta):
+    def expr_div(self, meta, value):
         return ExprOperator(
             a=value[0], op="/", b=value[2], notes=value[1], location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def unary_addressof(self, value, meta):
+    def unary_addressof(self, meta, value):
         return ExprAddressOf(expr=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def unary_neg(self, value, meta):
+    def unary_neg(self, meta, value):
         return ExprNeg(val=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def unary_new_operator(self, value, meta):
+    def unary_new_operator(self, meta, value):
         return ExprNewOperator(expr=value[0], is_typed=True, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def expr_pow(self, value, meta):
+    def expr_pow(self, meta, value):
         return ExprPow(a=value[0], b=value[2], notes=value[1], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_deref(self, value, meta):
+    def atom_deref(self, meta, value):
         return ExprDeref(addr=value[1], notes=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_subscript(self, value, meta):
+    def atom_subscript(self, meta, value):
         return ExprSubscript(
             expr=value[0], offset=value[2], notes=value[1], location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def atom_dot(self, value, meta):
+    def atom_dot(self, meta, value):
         return ExprDot(expr=value[0], member=value[1], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def atom_cast(self, value, meta):
+    def atom_cast(self, meta, value):
         return ExprCast(
             expr=value[1], notes=value[0], dest_type=value[2], location=self.meta2loc(meta)
         )
 
     @v_args(meta=True)
-    def atom_tuple_or_parentheses(self, value, meta):
+    def atom_tuple_or_parentheses(self, meta, value):
         (arg_list,) = value
         assert isinstance(arg_list, ArgList)
 
@@ -425,11 +425,11 @@ class ParserTransformer(Transformer):
     # Types.
 
     @v_args(meta=True)
-    def modifier_local(self, value, meta):
+    def modifier_local(self, meta, value):
         return Modifier(name="local", location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def typed_identifier(self, value, meta):
+    def typed_identifier(self, meta, value):
         assert len(value) in [1, 2, 3], f"Unexpected argument: value={value}"
         modifier = None
         if isinstance(value[0], Modifier):
@@ -444,27 +444,27 @@ class ParserTransformer(Transformer):
     # Instructions.
 
     @v_args(meta=True)
-    def inst_assert_eq(self, value, meta):
+    def inst_assert_eq(self, meta, value):
         return AssertEqInstruction(a=value[0], b=value[1], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def code_element_compound_assert_eq(self, value, meta):
+    def code_element_compound_assert_eq(self, meta, value):
         return CodeElementCompoundAssertEq(a=value[0], b=value[1], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_jmp_rel(self, value, meta):
+    def inst_jmp_rel(self, meta, value):
         return JumpInstruction(val=value[0], relative=True, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_jmp_abs(self, value, meta):
+    def inst_jmp_abs(self, meta, value):
         return JumpInstruction(val=value[0], relative=False, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_jmp_to_label(self, value, meta):
+    def inst_jmp_to_label(self, meta, value):
         return JumpToLabelInstruction(label=value[0], condition=None, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_jnz(self, value, meta):
+    def inst_jnz(self, meta, value):
         if value[2] != "0":
             raise ParserError('Invalid syntax, expected "!= 0".', location=self.meta2loc(meta))
         return JnzInstruction(
@@ -472,7 +472,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def inst_jnz_to_label(self, value, meta):
+    def inst_jnz_to_label(self, meta, value):
         if value[2] != "0":
             raise ParserError('Invalid syntax, expected "!= 0".', location=self.meta2loc(meta))
         return JumpToLabelInstruction(
@@ -480,41 +480,41 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def inst_call_rel(self, value, meta):
+    def inst_call_rel(self, meta, value):
         return CallInstruction(val=value[0], relative=True, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_call_abs(self, value, meta):
+    def inst_call_abs(self, meta, value):
         return CallInstruction(val=value[0], relative=False, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_call_label(self, value, meta):
+    def inst_call_label(self, meta, value):
         return CallLabelInstruction(label=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_add_ap(self, value, meta):
+    def inst_add_ap(self, meta, value):
         return AddApInstruction(expr=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_data_word(self, value, meta):
+    def inst_data_word(self, meta, value):
         return DefineWordInstruction(expr=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def inst_ret(self, value, meta):
+    def inst_ret(self, meta, value):
         return RetInstruction(location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def instruction_noap(self, value, meta):
+    def instruction_noap(self, meta, value):
         return InstructionAst(body=value[0], inc_ap=False, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def instruction_ap(self, value, meta):
+    def instruction_ap(self, meta, value):
         return InstructionAst(body=value[0], inc_ap=True, location=self.meta2loc(meta))
 
     # RValues.
 
     @v_args(meta=True)
-    def rvalue_expr(self, value, meta) -> Rvalue:
+    def rvalue_expr(self, meta, value) -> Rvalue:
         (expr,) = value
         if isinstance(expr, ExprFuncCall):
             return expr.rvalue
@@ -525,7 +525,7 @@ class ParserTransformer(Transformer):
         return RvalueCallInst(call_inst=call_inst)
 
     @v_args(meta=True)
-    def function_call(self, value, meta):
+    def function_call(self, meta, value):
         if len(value) == 2:
             func_ident, arg_list = value
             implicit_args = None
@@ -569,7 +569,7 @@ class ParserTransformer(Transformer):
         raise NotImplementedError(f"Unexpected argument: value={value}")
 
     @v_args(meta=True)
-    def code_element_local_var(self, value, meta):
+    def code_element_local_var(self, meta, value):
         if len(value) == 1:
             typed_identifier = value[0]
             expr = None
@@ -583,7 +583,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_temp_var(self, value, meta):
+    def code_element_temp_var(self, meta, value):
         typed_identifier, *maybe_expr = value
         (expr,) = maybe_expr if len(maybe_expr) > 0 else [None]
 
@@ -594,11 +594,11 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_static_assert(self, value, meta):
+    def code_element_static_assert(self, meta, value):
         return CodeElementStaticAssert(a=value[0], b=value[1], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def code_element_return(self, value, meta):
+    def code_element_return(self, meta, value):
         (expr,) = value
         if isinstance(expr, ExprFuncCall):
             return CodeElementTailCall(func_call=expr.rvalue, location=self.meta2loc(meta))
@@ -617,7 +617,7 @@ class ParserTransformer(Transformer):
         return CodeElementLabel(identifier=identifier)
 
     @v_args(meta=True)
-    def code_element_hint(self, value, meta):
+    def code_element_hint(self, meta, value):
         return CodeElementHint(
             hint=ExprHint.from_str(val=value[0], location=self.meta2loc(meta)),
             location=self.meta2loc(meta),
@@ -627,7 +627,7 @@ class ParserTransformer(Transformer):
         return CodeElementEmptyLine()
 
     @v_args(meta=True)
-    def commented_code_element(self, value, meta):
+    def commented_code_element(self, meta, value):
         comment = value[1][2:] if len(value) == 2 else None
         return CommentedCodeElement(
             code_elm=value[0], comment=comment, location=self.meta2loc(meta)
@@ -637,7 +637,7 @@ class ParserTransformer(Transformer):
         return CodeBlock(code_elements=value)
 
     @v_args(meta=True)
-    def identifier_list(self, value, meta):
+    def identifier_list(self, meta, value):
         identifiers = value[1:-1:3]
         # Join the notes before and after the comma.
         notes = [value[0]] + [value[i] + value[i + 1] for i in range(2, len(value) - 1, 3)]
@@ -705,7 +705,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_typedef(self, value, meta):
+    def code_element_typedef(self, meta, value):
         return CodeElementTypeDef(
             identifier=value[0], cairo_type=value[1], location=self.meta2loc(meta)
         )
@@ -734,7 +734,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_if(self, value, meta):
+    def code_element_if(self, meta, value):
         condition = value[0]
         main_code_block = value[1]
         if len(value) == 2:
@@ -763,20 +763,20 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_directive(self, value, meta):
+    def code_element_directive(self, meta, value):
         return CodeElementDirective(directive=value[0], location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def directive_builtins(self, value, meta):
+    def directive_builtins(self, meta, value):
         builtins = [ident.name for ident in value[1:]]
         return BuiltinsDirective(builtins=builtins, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def directive_lang(self, value, meta):
+    def directive_lang(self, meta, value):
         return LangDirective(name=value[1].name, location=self.meta2loc(meta))
 
     @v_args(meta=True)
-    def aliased_identifier(self, value, meta):
+    def aliased_identifier(self, meta, value):
         if len(value) == 1:
             # Element of the form: <identifier>.
             (identifier,) = value
@@ -792,7 +792,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_import(self, value, meta):
+    def code_element_import(self, meta, value):
         path = value[0]
         if isinstance(value[1], AliasedIdentifier):
             # Single line.
@@ -813,7 +813,7 @@ class ParserTransformer(Transformer):
         )
 
     @v_args(meta=True)
-    def code_element_alloc_locals(self, value, meta):
+    def code_element_alloc_locals(self, meta, value):
         return CodeElementAllocLocals(location=self.meta2loc(meta))
 
     def cairo_file(self, value):
@@ -825,7 +825,7 @@ class ParserTransformer(Transformer):
         return "\n"
 
     @v_args(meta=True)
-    def notes(self, value, meta):
+    def notes(self, meta, value):
         """
         Collects the comments in the AST node, marking whether the notes starts with a new line.
         """


### PR DESCRIPTION
This closes #75 and uses the up-to-date package from PyPI (`lark-parser` seems to be abandoned from the author, who chose to rename its package to `lark`).

It also introduced a breakage change at version 1.0 where `standard` was renamed `basic`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/88)
<!-- Reviewable:end -->
