### PR TITLE
🚸 add vscode snippets for `@raw_input`/`@raw_output` functions

### DIFF
--- a/src/starkware/cairo/lang/ide/vscode-cairo/snippets.json
+++ b/src/starkware/cairo/lang/ide/vscode-cairo/snippets.json
@@ -25,6 +25,53 @@
         ],
         "description": "A StarkNet contract external function."
     },
+    "Raw input function": {
+        "prefix": [
+            "@raw_input"
+        ],
+        "body": [
+            "@raw_input",
+            "func ${1:name}{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(",
+            "\tselector : felt, calldata_size : felt, calldata : felt*",
+            "):",
+            "\t$0",
+            "end"
+        ],
+        "description": "A StarkNet contract raw_input function."
+    },
+    "Raw output function": {
+        "prefix": [
+            "@raw_output"
+        ],
+        "body": [
+            "@raw_output",
+            "func ${1:name}{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(",
+            "\t${2:arguments}",
+            ") -> ",
+            "(retdata_size : felt, retdata : felt*)",
+            ":",
+            "\t$0",
+            "end"
+        ],
+        "description": "A StarkNet contract raw_output function."
+    },
+    "Raw input/output function": {
+        "prefix": [
+            "@raw_inout"
+        ],
+        "body": [
+            "@raw_input",
+            "@raw_output",
+            "func ${1:name}{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(",
+            "\tselector : felt, calldata_size : felt, calldata : felt*",
+            ") -> ",
+            "(retdata_size : felt, retdata : felt*)",
+            ":",
+            "\t$0",
+            "end"
+        ],
+        "description": "A StarkNet contract raw_input and raw_output function."
+    },
     "StarkNet contract interface": {
         "prefix": [
             "@contract_interface"


### PR DESCRIPTION
Inspired by the snippet of the external functions, this snippet improves
the DX by adding three snippets.
- The first one to easy create a `raw_input` function
- The second one to easy create a `raw_output` function
- The last one to easy create a function that is `raw_input` and `raw_output` at the same time