### PR TITLE
👷 setup on-demand CI run for pull request

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -1,0 +1,50 @@
+# this workflow only run when someone comment "run_ci" in the PR
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  build-and-test:
+    name: Build the language, build the vscode extension and run the tests
+    runs-on: ubuntu-latest
+    steps:
+      # test if the predefined keyword that triggers the workflow has been send
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: "run_ci"
+          reaction: rocket
+          prefix_only: true
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # only run the following steps if someone commented "run_ci"
+      - name: Checkout code
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.triggered == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker image
+        if: steps.check.outputs.triggered == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          push: false
+          load: true
+          tags: ${{ github.event.repository.name }}:latest, ${{ github.repository }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
A new workflow that builds the repository builds the VSCode extension, and runs the tests will now run every time someone sends "run_ci" as a comment in a PR. The command must start the message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-lang/106)
<!-- Reviewable:end -->
