### PR TITLE
uint256_mod_inv standard function with a hint

### DIFF
--- a/src/starkware/cairo/common/uint256.cairo
+++ b/src/starkware/cairo/common/uint256.cairo
@@ -408,6 +408,22 @@ func uint256_pow2{range_check_ptr}(exp: Uint256) -> (res: Uint256) {
     }
 }
 
+// Computes modular inversion x^{-1} % p.
+func uint256_mod_inv{range_check_ptr: felt}(x: Uint256, p: Uint256) -> (res: Uint256) {
+    alloc_locals;
+    local res: Uint256;
+    %{
+        x = (ids.x.high << 128) + ids.x.low
+        p = (ids.p.high << 128) + ids.p.low
+        res = pow(x, -1, p)
+        ids.res.low = res & ((1 << 128) - 1)
+        ids.res.high = res >> 128
+    %}
+    let (quotient_low, quotient_high, remainder) = uint256_mul_div_mod(x,res,p);
+    assert Uint256(low=1,high=0) = (remainder);
+    return (res=res);
+}
+
 // Computes the logical left shift of a uint256 integer.
 func uint256_shl{range_check_ptr}(a: Uint256, b: Uint256) -> (res: Uint256) {
     let (c) = uint256_pow2(b);

--- a/src/starkware/cairo/common/uint256.cairo
+++ b/src/starkware/cairo/common/uint256.cairo
@@ -408,18 +408,18 @@ func uint256_pow2{range_check_ptr}(exp: Uint256) -> (res: Uint256) {
     }
 }
 
-// Computes modular inversion x^{-1} % p.
-func uint256_mod_inv{range_check_ptr: felt}(x: Uint256, p: Uint256) -> (res: Uint256) {
+// Computes modular inversion a^{-1} % div.
+func uint256_mod_inv{range_check_ptr: felt}(a: Uint256, div: Uint256) -> (res: Uint256) {
     alloc_locals;
     local res: Uint256;
     %{
-        x = (ids.x.high << 128) + ids.x.low
-        p = (ids.p.high << 128) + ids.p.low
-        res = pow(x, -1, p)
+        a = (ids.a.high << 128) + ids.a.low
+        div = (ids.div.high << 128) + ids.div.low
+        res = pow(a, -1, div)
         ids.res.low = res & ((1 << 128) - 1)
         ids.res.high = res >> 128
     %}
-    let (quotient_low, quotient_high, remainder) = uint256_mul_div_mod(x,res,p);
+    let (quotient_low, quotient_high, remainder) = uint256_mul_div_mod(a,res,div);
     assert Uint256(low=1,high=0) = (remainder);
     return (res=res);
 }


### PR DESCRIPTION
It would be awesome if we could get this method included in the standard library and whitelisted for usage in starknet since it uses a hint and immediately checks it with this part of the code:
```
    let (quotient_low, quotient_high, remainder) = uint256_mul_div_mod(a,res,div);
    assert Uint256(low=1,high=0) = (remainder);
```

Modular inversion is one of the essential elliptic curve computations. And here we have a nice trick to calculate it in the hint and check if after the hint.

For comparison to the EVM: EVM has a precompiled expmod [link](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-198.md) but implementing expmod in cairo and starknet is another story because of the current state of sequencers on starknet(expmod is computationally heavy computation(~500k steps in cairo for an exponent of 256-bit). And if it is computed in the hint, I currently can't think of any way to check if it is correctly computed in the hint since that would require something like `assert quotient*modulus + remainder = base^exponent` which is also very expensive for cairo and starknet.

But at least having `uint256_mod_inv` makes sense