### PR TITLE
Fix invalid multiline string in response_objects.py

### DIFF
--- a/src/starkware/starknet/services/api/feeder_gateway/response_objects.py
+++ b/src/starkware/starknet/services/api/feeder_gateway/response_objects.py
@@ -314,9 +314,11 @@ class TransactionInBlockInfo(ValidatedResponseObject):
             else:
                 assert (self.execution_status is None) and (
                     self.transaction_failure_reason is None
-                ), f"For a non-reverted transaction with finality status: {self.finality_status}, "
-                f"the following fields must be None, but are instead: "
-                f"{self.execution_status=}, {self.transaction_failure_reason=}."
+                ), (
+                    f"For a non-reverted transaction with finality status: {self.finality_status}, "
+                    f"the following fields must be None, but are instead: "
+                    f"{self.execution_status=}, {self.transaction_failure_reason=}."
+                )
 
             return
 


### PR DESCRIPTION
Missing parentheses lead to incomplete AssertionError message such as this one:
```
AssertionError: For a non-reverted transaction with finality status: FinalityStatus.RECEIVED, 
```
