### PR TITLE
Add all_cairo layout to exported const

### DIFF
--- a/src/starkware/cairo/lang/instances.py
+++ b/src/starkware/cairo/lang/instances.py
@@ -553,4 +553,5 @@ LAYOUTS: Dict[str, CairoLayout] = {
     "starknet_with_keccak": starknet_with_keccak_instance,
     "dynamic": build_dynamic_layout(),
     "recursive_with_poseidon": recursive_with_poseidon_instance,
+    "all_cairo": all_cairo_instance,
 }


### PR DESCRIPTION
The all_cairo layout isn't available from the CLI if this constant is not updated.

Not sure it wouldn't be part of it since it's well defined.

Especially, this is useful to use the CLI with program using `range_check96`