### PR TITLE
Add check for missing contract address in deployment receipt Update d…

### DIFF
--- a/src/demo/amm_demo/demo.py
+++ b/src/demo/amm_demo/demo.py
@@ -87,6 +87,14 @@ def deploy_contract(batch_prover: BatchProver, w3: Web3, operator: BaseAccount) 
     )
     print("Deploying the AMM demo smart contract...")
     tx_receipt = send_transaction(w3, transaction, operator)
+
+    # Check if the contract address is found in the tx_receipt
+        if tx_receipt.get("contractAddress"):
+        contract_address = tx_receipt["contractAddress"]
+        else:
+        print("Error: Contract address not found.")
+        exit(1)
+    
     assert (
         tx_receipt["status"] == 1
     ), f'Failed to deploy contract. Transaction hash: {tx_receipt["transactionHash"]}.'


### PR DESCRIPTION
#### Description:
In some cases, if the contract deployment is unsuccessful, the `tx_receipt["contractAddress"]` variable might be `None`. This can lead to errors when trying to use it later in the code. To prevent this issue, I have added a check before accessing the `contractAddress` key in the transaction receipt.

#### Changes made:
- Added a condition to check whether the `tx_receipt` contains the key `"contractAddress"`.
- If the key is missing, the program now prints an error message and exits gracefully using `exit(1)`.
- If the key is found, the contract address is assigned to the `contract_address` variable, and the program continues.

#### Code:
```python
tx_receipt = send_transaction(w3, transaction, operator)

# Check if the contract address is found in tx_receipt
if tx_receipt.get("contractAddress"):
    contract_address = tx_receipt["contractAddress"]
else:
    print("Error: Contract address not found.")
    exit(1)
```

#### Explanation of the fix:
This fix ensures that the program handles the scenario where the contract deployment fails and the contract address is not available in the transaction receipt. Without this check, the program would crash when trying to access the contract address. This fix improves the robustness of the contract deployment process and prevents potential runtime errors.
