### PR TITLE
Fix Comment Syntax in Code Update storage.cairo

### DIFF
--- a/src/starkware/starknet/common/storage.cairo
+++ b/src/starkware/starknet/common/storage.cairo
@@ -1,13 +1,13 @@
 from starkware.cairo.common.math import assert_250_bit
 
 const MAX_STORAGE_ITEM_SIZE = 256;
-// Valid storage addresses should satisfy address + offset < 2**251 where
-// offset < MAX_STORAGE_ITEM_SIZE and address < ADDR_BOUND.
+# Valid storage addresses should satisfy address + offset < 2**251 where
+# offset < MAX_STORAGE_ITEM_SIZE and address < ADDR_BOUND.
 const ADDR_BOUND = 2 ** 251 - MAX_STORAGE_ITEM_SIZE;
 
-// Computes addr % ADDR_BOUND so that the result will form a valid storage item address in the
-// storage tree. In particular, we need the result + MAX_STORAGE_ITEM_SIZE to be less than
-// 2**251.
+# Computes addr % ADDR_BOUND so that the result will form a valid storage item address in the
+# storage tree. In particular, we need the result + MAX_STORAGE_ITEM_SIZE to be less than
+# 2**251.
 @known_ap_change
 func normalize_address{range_check_ptr}(addr: felt) -> (res: felt) {
     tempvar is_small;
@@ -24,27 +24,27 @@ func normalize_address{range_check_ptr}(addr: felt) -> (res: felt) {
         %{ ids.is_250 = 1 if ids.addr < 2**250 else 0 %}
         if (is_250 != 0) {
             ap += 11;
-            // In this case addr < 2**250 < ADDR_BOUND, so addr % ADDR_BOUND = addr.
+            # In this case addr < 2**250 < ADDR_BOUND, so addr % ADDR_BOUND = addr.
             assert_250_bit(addr);
         } else {
             ap += 10;
-            // In this case 0 <= ADDR_BOUND - 1 - addr < 2**250, so addr < ADDR_BOUND.
+            # In this case 0 <= ADDR_BOUND - 1 - addr < 2**250, so addr < ADDR_BOUND.
             assert_250_bit(ADDR_BOUND - 1 - addr);
         }
         return (res=addr);
     } else {
-        // The first call to assert_250_bit() checks that 0 <= (addr - ADDR_BOUND) % PRIME < 2**250.
-        // The second call checks that 0 <= (-1 - addr) % PRIME < 2**250.
-        // Let x = (addr - ADDR_BOUND) % PRIME and y = (-1 - addr) % PRIME. Then,
-        //   x + y = (addr - ADDR_BOUND) + (-1 - addr) = PRIME - 1 - ADDR_BOUND  (mod PRIME).
-        // So we have:
-        //   x + y = PRIME - 1 - ADDR_BOUND  (mod PRIME).
-        // Since both hands are in the range [0, PRIME) (since 2 * 2**250 < PRIME),
-        // they must be equal as integers.
-        // In particular, x + ADDR_BOUND = PRIME - 1 - y < PRIME.
-        // Since addr = x + ADDR_BOUND (mod PRIME) and both sides are in the range [0, PRIME)
-        // we have addr = x + ADDR_BOUND (as integers).
-        // Therefore, we should subtract ADDR_BOUND to get addr % ADDR_BOUND.
+        # The first call to assert_250_bit() checks that 0 <= (addr - ADDR_BOUND) % PRIME < 2**250.
+        # The second call checks that 0 <= (-1 - addr) % PRIME < 2**250.
+        # Let x = (addr - ADDR_BOUND) % PRIME and y = (-1 - addr) % PRIME. Then,
+        #   x + y = (addr - ADDR_BOUND) + (-1 - addr) = PRIME - 1 - ADDR_BOUND  (mod PRIME).
+        # So we have:
+        #   x + y = PRIME - 1 - ADDR_BOUND  (mod PRIME).
+        # Since both hands are in the range [0, PRIME) (since 2 * 2**250 < PRIME),
+        # they must be equal as integers.
+        # In particular, x + ADDR_BOUND = PRIME - 1 - y < PRIME.
+        # Since addr = x + ADDR_BOUND (mod PRIME) and both sides are in the range [0, PRIME)
+        # we have addr = x + ADDR_BOUND (as integers).
+        # Therefore, we should subtract ADDR_BOUND to get addr % ADDR_BOUND.
         let x = addr - ADDR_BOUND;
         let y = (-1) - addr;
         assert_250_bit(x);


### PR DESCRIPTION
#### Summary:
This pull request addresses a syntax issue with comment formatting in the code. Specifically, it corrects the usage of `//` for comments, which was originally used in places where `#` should have been employed, following the conventions of StarkNet (or Cairo) language. 

#### Issue:
The original code used the following comment syntax:
```python
// Valid storage addresses should satisfy address + offset < 2**251 where
// offset < MAX_STORAGE_ITEM_SIZE and address < ADDR_BOUND.
```
However, in StarkNet and Cairo, comments should be written using `#`, not `//` (which is common in languages like JavaScript or Python). This inconsistency may cause confusion for developers working with the codebase, as it deviates from the expected conventions of the language.

#### Fix:
The comments have been updated to use the correct syntax, as shown below:
```python
# Valid storage addresses should satisfy address + offset < 2**251 where
# offset < MAX_STORAGE_ITEM_SIZE and address < ADDR_BOUND.
```

#### Importance:
This change is important because adhering to the correct comment syntax is essential for maintaining consistency within the codebase. It ensures that developers using the StarkNet or Cairo environment can easily read and understand the code without confusion. Proper comment formatting also helps maintain the overall quality and readability of the code, especially in collaborative development environments.

Thank you for reviewing this change!
**Love StarkNet!**