### PR TITLE
Fix typographical errors

### DIFF
--- a/src/services/everest/business_logic/state_api.py
+++ b/src/services/everest/business_logic/state_api.py
@@ -3,5 +3,5 @@ from abc import ABC
 
 class StateProxy(ABC):
     """
-    A proxy to the state, exposing the sufficient functionallity to run a transaction.
+    A proxy to the state, exposing the sufficient functionality to run a transaction.
     """

--- a/src/services/external_api/client.py
+++ b/src/services/external_api/client.py
@@ -80,7 +80,7 @@ class BadRequest(Exception):
         self.text = text
 
     def __repr__(self) -> str:
-        return f"HTTP error ocurred. Status: {self.status_code}. Text: {self.text}"
+        return f"HTTP error occurred. Status: {self.status_code}. Text: {self.text}"
 
     def __str__(self) -> str:
         """

--- a/src/starkware/cairo/lang/compiler/parser_test.py
+++ b/src/starkware/cairo/lang/compiler/parser_test.py
@@ -928,7 +928,7 @@ def test_func_expr():
 def test_parent_location():
     location = parse_expr("1 + 2").location
     assert location is not None
-    parent_location = (location, "An error ocurred while processing:")
+    parent_location = (location, "An error occurred while processing:")
 
     code_element = parse_code_element(
         "let x = 3 + 4;", parser_context=ParserContext(parent_location=parent_location)
@@ -939,7 +939,7 @@ def test_parent_location():
     assert (
         str(location_err)
         == """\
-:1:1: An error ocurred while processing:
+:1:1: An error occurred while processing:
 1 + 2
 ^***^
 :1:9: Error

--- a/src/starkware/starknet/common/syscalls.cairo
+++ b/src/starkware/starknet/common/syscalls.cairo
@@ -100,7 +100,7 @@ func library_call{syscall_ptr: felt*}(
     return (retdata_size=response.retdata_size, retdata=response.retdata);
 }
 
-// Simialr to library_call(), except that the entry point is an L1 handler,
+// Similar to library_call(), except that the entry point is an L1 handler,
 // rather than an external function.
 // Note that this function does not consume an L1 message,
 // and thus it should only be called from a corresponding L1 handler.

--- a/src/starkware/starknet/core/os/contract_class/compiled_class.cairo
+++ b/src/starkware/starknet/core/os/contract_class/compiled_class.cairo
@@ -342,7 +342,7 @@ func guess_compiled_class_facts{poseidon_ptr: PoseidonBuiltin*, range_check_ptr}
             cairo_contract = get_compiled_class_struct(
                 identifiers=ids._context.identifiers,
                 compiled_class=compiled_class,
-                # Load the entire bytecode - the unaccessed segments will be overriden and skipped
+                # Load the entire bytecode - the unaccessed segments will be overridden and skipped
                 # after the execution, in `validate_compiled_class_facts_post_execution`.
                 bytecode=compiled_class.bytecode,
             )

--- a/src/starkware/starknet/core/os/data_availability/compression.cairo
+++ b/src/starkware/starknet/core/os/data_availability/compression.cairo
@@ -25,7 +25,7 @@ struct Header {
     // Total data length before compression.
     data_len: felt,
     unique_value_bucket_lengths: UniqueValueBucketLengths,
-    // Number of elements in the special bucket that holds pointers of repeating vaules.
+    // Number of elements in the special bucket that holds pointers of repeating values.
     n_repeating_values: felt,
 }
 

--- a/src/starkware/starknet/core/os/data_availability/compression.py
+++ b/src/starkware/starknet/core/os/data_availability/compression.py
@@ -60,7 +60,7 @@ class UniqueValueBucket:
 class CompressionSet:
     """
     A utility class for compression.
-    Used to manage and store the unique values in seperate buckets according to their bit length.
+    Used to manage and store the unique values in separate buckets according to their bit length.
     """
 
     def __init__(self, n_bits_per_bucket: List[int]):

--- a/src/starkware/starknet/services/api/contract_class/contract_class.py
+++ b/src/starkware/starknet/services/api/contract_class/contract_class.py
@@ -162,7 +162,7 @@ class CompiledClassBase(ValidatedMarshmallowDataclass):
     @abstractmethod
     def is_cairo1(self) -> bool:
         """
-        Retruns whether the class was compiled from Cairo 1.
+        Returns whether the class was compiled from Cairo 1.
         """
 
     def __post_init__(self):


### PR DESCRIPTION
 - In `state_api.py`: "functionallity" corrected to "functionality".
   - In `client.py`: "ocurred" corrected to "occurred".
   - In `parser_test.py`: "ocurred" corrected to "occurred".
   - In `syscalls.cairo`: "Simialr" corrected to "Similar".
   - In `compiled_class.cairo`: "overriden" corrected to "overridden".
   - In `compression.cairo`: "vaules" corrected to "values".
   - In `compression.py`: "seperate" corrected to "separate".
   - In `contract_class.py`: "Retruns" corrected to "Returns".
