### PR TITLE
Update Broken Tutorial Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We recommend starting from [Setting up the environment](https://cairo-lang.org/d
 # Installation instructions
 
 You should be able to download the python package zip file directly from
-[github](https://github.com/starkware-libs/cairo-lang/releases/tag/v0.14.0)
+[github]()
 and install it using ``pip``.
 See [Setting up the environment](https://cairo-lang.org/docs/quickstart.html).
 


### PR DESCRIPTION
The current tutorial link in the README is broken.
If you have suggestions for a replacement, please let me know, and I will update it. Otherwise, we can simply remove the link.
The latest available version is v0.13.5.