### PR TITLE
docs: clarify deterministic lowering behavior in Cairo compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ Once the docker image is built, you can fetch the python package zip file using:
 > docker cp ${container_id}:/app/cairo-lang-0.14.1.zip .
 > docker rm -v ${container_id}
 ```
+> Note: The Starknet compiler performs deterministic Cairo-to-Sierra
+> lowering. Any nondeterministic behavior indicates an upstream toolchain issue.
+


### PR DESCRIPTION
This PR adds a short clarification to the documentation regarding the
deterministic nature of the Cairo-to-Sierra lowering process in the
Starknet toolchain.

The note explains that the lowering step is expected to be deterministic,
so any nondeterministic behavior during compilation should be considered
an upstream toolchain or compiler issue. This helps developers understand
expected compiler behavior when debugging complex builds.

This is a documentation-only change and does not modify any code.
